### PR TITLE
Adding states to Norbert network server side

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
@@ -170,14 +170,21 @@ trait ClusterClient extends Logging {
   }
 
   /**
+   * Marks a cluster node as online with capability value set to 0L
+   *
+   * @param nodeId  the id of the node to mark available
+   */
+  def markNodeAvailable(nodeId: Int): Unit = markNodeAvailable(nodeId, 0L)
+
+  /**
    * Marks a cluster node as online and available for receiving requests.
    *
    * @param nodeId the id of the node to mark available
    *
    * @throws ClusterDisconnectedException thrown if the cluster is disconnected when the method is called
    */
-  def markNodeAvailable(nodeId: Int): Unit = handleClusterManagerResponse {
-    clusterManager !? ClusterManagerMessages.MarkNodeAvailable(nodeId)
+  def markNodeAvailable(nodeId: Int, initialCapability: Long = 0L): Unit = handleClusterManagerResponse {
+    clusterManager !? ClusterManagerMessages.MarkNodeAvailable(nodeId, initialCapability)
   }
 
   /**
@@ -189,6 +196,16 @@ trait ClusterClient extends Logging {
    */
   def markNodeUnavailable(nodeId: Int): Unit = handleClusterManagerResponse {
     clusterManager !? ClusterManagerMessages.MarkNodeUnavailable(nodeId)
+  }
+
+  /**
+   * Set the capability state for a cluster node
+   * @param nodeId the id of the node to represent capablity
+   *
+   * @throws ClusterDisconnectedException thrown if the clsuter is disconnected when the method is called
+   */
+  def setNodeCapability(nodeId: Int, capability: Long): Unit = handleClusterManagerResponse {
+    clusterManager !? ClusterManagerMessages.SetNodeCapability(nodeId, capability)
   }
 
   /**

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/ClusterClient.scala
@@ -199,8 +199,12 @@ trait ClusterClient extends Logging {
   }
 
   /**
-   * Set the capability state for a cluster node
+   * Set the capability state for a cluster node.
+   *
    * @param nodeId the id of the node to represent capablity
+   * @param capability a long with each bit of it representing a different capability of the Node, thus, supporting up
+   * to 64 different capabilities of the Node. This capability then can be used to filter nodes only fulfill a certain
+   * capability level during Node query.
    *
    * @throws ClusterDisconnectedException thrown if the clsuter is disconnected when the method is called
    */

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
@@ -83,5 +83,5 @@ final case class Node(id: Int, url: String, available: Boolean, partitionIds: Se
     case _ => false
   }
 
-  override def toString = "Node(%d,%s,[%s],%b,%d)".format(id, url, partitionIds.mkString(","), available, if (capability.isEmpty) -1L else capability.get)
+  override def toString = "Node(%d,%s,[%s],%b,0x%08X)".format(id, url, partitionIds.mkString(","), available, if (capability.isEmpty) 0L else capability.get)
 }

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
@@ -34,14 +34,14 @@ object Node {
    *
    * @return a new <code>Node</code> instance
    */
-  def apply(id: Int, bytes: Array[Byte], available: Boolean): Node = {
+  def apply(id: Int, bytes: Array[Byte], available: Boolean, capability : Option[Long]): Node = {
     import collection.JavaConversions._
 
     try {
       val node = NorbertProtos.Node.newBuilder.mergeFrom(bytes).build
       val partitions = node.getPartitionList.asInstanceOf[java.util.List[Int]].foldLeft(Set[Int]()) { (set, i) => set + i }
 
-      Node(node.getId, node.getUrl, available, partitions)
+      Node(node.getId, node.getUrl, available, partitions, capability)
     } catch {
       case ex: InvalidProtocolBufferException => throw new InvalidNodeException("Error deserializing node", ex)
     }
@@ -70,8 +70,9 @@ object Node {
  * @param address the url to which requests can be sent to the node
  * @param available whether or not the node is currently able to process requests
  * @param partitions the partitions for which the node can handle requests
+ * @param capability the 64 bits Long representing up to 64 node capabilities
  */
-final case class Node(id: Int, url: String, available: Boolean, partitionIds: Set[Int] = Set.empty) {
+final case class Node(id: Int, url: String, available: Boolean, partitionIds: Set[Int] = Set.empty, capability: Option[Long] = None) {
   if (url == null) throw new NullPointerException("url must not be null")
   if (partitionIds == null) throw new NullPointerException("partitions must not be null")
 
@@ -82,5 +83,5 @@ final case class Node(id: Int, url: String, available: Boolean, partitionIds: Se
     case _ => false
   }
 
-  override def toString = "Node(%d,%s,[%s],%b)".format(id, url, partitionIds.mkString(","), available)
+  override def toString = "Node(%d,%s,[%s],%b,%d)".format(id, url, partitionIds.mkString(","), available, if (capability.isEmpty) -1L else capability.get)
 }

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/common/ClusterManagerComponent.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/common/ClusterManagerComponent.scala
@@ -26,8 +26,9 @@ trait ClusterManagerComponent {
   object ClusterManagerMessages {
     case class AddNode(node: Node) extends ClusterManagerMessage
     case class RemoveNode(nodeId: Int) extends ClusterManagerMessage
-    case class MarkNodeAvailable(nodeId: Int) extends ClusterManagerMessage
+    case class MarkNodeAvailable(nodeId: Int, initialCapability: Long = 0L) extends ClusterManagerMessage
     case class MarkNodeUnavailable(nodeId: Int) extends ClusterManagerMessage
+    case class SetNodeCapability(nodeId: Int,  capability: Long) extends ClusterManagerMessage
 
     case object Shutdown extends ClusterManagerMessage
 

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/memory/InMemoryClusterManagerComponent.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/memory/InMemoryClusterManagerComponent.scala
@@ -54,16 +54,21 @@ trait InMemoryClusterManagerComponent extends ClusterManagerComponent with Clust
             clusterNotificationManager ! ClusterNotificationMessages.NodesChanged(currentNodes)
             reply(ClusterManagerResponse(None))
 
-          case MarkNodeAvailable(nodeId) =>
-            currentNodes.get(nodeId).foreach { node => currentNodes.update(nodeId, node.copy(available = true)) }
+          case MarkNodeAvailable(nodeId, initialCapability) =>
+            currentNodes.get(nodeId).foreach { node => currentNodes.update(nodeId, node.copy(available = true, capability =  Some(initialCapability))) }
             available += nodeId
             clusterNotificationManager ! ClusterNotificationMessages.NodesChanged(currentNodes)
             reply(ClusterManagerResponse(None))
 
           case MarkNodeUnavailable(nodeId) =>
-            currentNodes.get(nodeId).foreach { node => currentNodes.update(nodeId, node.copy(available = false)) }
+            currentNodes.get(nodeId).foreach { node => currentNodes.update(nodeId, node.copy(available = false, capability = None)) }
             available -= nodeId
             clusterNotificationManager ! ClusterNotificationMessages.NodesChanged(currentNodes)
+            reply(ClusterManagerResponse(None))
+
+          case SetNodeCapability(nodeId, capability) =>
+            currentNodes.get(nodeId).foreach { node => currentNodes.update(nodeId, node.copy(capability = Some(capability)))}
+            clusterManager ! ClusterNotificationMessages.NodesChanged(currentNodes)
             reply(ClusterManagerResponse(None))
 
           case Shutdown => exit

--- a/cluster/src/test/scala/com/linkedin/norbert/cluster/ClusterClientSpec.scala
+++ b/cluster/src/test/scala/com/linkedin/norbert/cluster/ClusterClientSpec.scala
@@ -88,7 +88,7 @@ class ClusterClientSpec extends Specification with Mockito with WaitFor {
             nodeRemovedId = id
             reply(ClusterManagerMessages.ClusterManagerResponse(None))
 
-          case ClusterManagerMessages.MarkNodeAvailable(id) =>
+          case ClusterManagerMessages.MarkNodeAvailable(id, initialCapability) =>
             markNodeAvailableCount += 1
             markNodeAvailableId = id
             reply(ClusterManagerMessages.ClusterManagerResponse(None))

--- a/cluster/src/test/scala/com/linkedin/norbert/cluster/NodeSpec.scala
+++ b/cluster/src/test/scala/com/linkedin/norbert/cluster/NodeSpec.scala
@@ -28,8 +28,8 @@ class NodeSpec extends Specification {
       builder.addPartition(0).addPartition(1)
       val expectedBytes = builder.build.toByteArray.toList
 
-      val nodeBytes = Node.nodeToByteArray(Node(1, "localhost:31313", false, Set(0, 1))).toList
-      nodeBytes must be_==(expectedBytes)
+      val nodeBytes = Node.nodeToByteArray(Node(1, "localhost:31313", false, Set(0, 1)))
+      nodeBytes.toList must be_==(expectedBytes)
     }
 
     "deserialize into the corrent Node" in {
@@ -40,7 +40,7 @@ class NodeSpec extends Specification {
       val bytes = builder.build.toByteArray
 
       val node = Node(1, "localhost:31313", true, Set(0, 1))
-      Node(1, bytes, true) must be_==(node)
+      Node(1, bytes, true, Some(0L)) must be_==(node)
     }
 
     "have a sane equals method" in {

--- a/java-cluster/src/main/java/com/linkedin/norbert/javacompat/cluster/ClusterClient.java
+++ b/java-cluster/src/main/java/com/linkedin/norbert/javacompat/cluster/ClusterClient.java
@@ -90,13 +90,24 @@ public interface ClusterClient {
   void removeNode(int nodeId) throws ClusterDisconnectedException;
 
   /**
-   * Marks a cluster node as online and available for receiving requests.
+   * Marks a cluster node as online and available for receiving requests, the capability value associated
+   * with this node is 0L
    *
    * @param nodeId the id of the node to mark available
    *
    * @throws ClusterDisconnectedException thrown if the cluster is disconnected when the method is called
    */
   void markNodeAvailable(int nodeId) throws ClusterDisconnectedException;
+
+  /**
+   * Marks a cluster node as online with an initial capability string to receive requests.
+   *
+   * @param nodeId  the id of the node to mark available
+   * @param capability the capability value associated to the node when it is up
+   *
+   * @throws ClusterDisconnectedException
+   */
+  void markNodeAvailable(int nodeId, long capability) throws ClusterDisconnectedException;
 
   /**
    * Marks a cluster node as offline and unavailable for receiving requests.

--- a/java-cluster/src/main/scala/com/linkedin/norbert/javacompat/cluster/BaseClusterClient.scala
+++ b/java-cluster/src/main/scala/com/linkedin/norbert/javacompat/cluster/BaseClusterClient.scala
@@ -51,6 +51,8 @@ abstract class BaseClusterClient extends ClusterClient {
   def markNodeUnavailable(nodeId: Int) = underlying.markNodeUnavailable(nodeId)
 
   def markNodeAvailable(nodeId: Int) = underlying.markNodeAvailable(nodeId)
+  
+  def markNodeAvailable(nodeId: Int, capacity: Long) = underlying.markNodeAvailable(nodeId, capacity)
 
   def removeNode(nodeId: Int) = underlying.removeNode(nodeId)
 

--- a/java-network/src/main/java/com/linkedin/norbert/javacompat/network/NetworkServer.java
+++ b/java-network/src/main/java/com/linkedin/norbert/javacompat/network/NetworkServer.java
@@ -59,6 +59,22 @@ public interface NetworkServer {
   void bind(int nodeId, boolean markAvailable) throws InvalidNodeException, NetworkingException;
 
   /**
+   * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
+   * by the provided nodeId and marks the <code>Node</code> available in the cluster if <code>markAvailable</code> is true.  A
+   * <code>Node</code>'s url must be specified in the format hostname:port.
+   *
+   * @param nodeId the id of the <code>Node</code> this server is associated with.
+   * @param markAvailable if true marks the <code>Node</code> identified by <code>nodeId</code> as available after binding to
+   * the port
+   * @param initialCapacity the initial capability value associated with the node
+   *
+   * @throws InvalidNodeException thrown if no <code>Node</code> with the specified <code>nodeId</code> exists or if the
+   * format of the <code>Node</code>'s url isn't hostname:port
+   * @throws NetworkingException thrown if unable to bind
+   */
+  void bind(int nodeId, boolean markAvailable, long initialCapability) throws InvalidNodeException, NetworkingException;
+
+  /**
    * Returns the <code>Node</code> associated with this server.
    *
    * @return the <code>Node</code> associated with this server
@@ -69,6 +85,12 @@ public interface NetworkServer {
    * Marks the node available in the cluster if the server is bound.
    */
   void markAvailable();
+
+  /**
+   * Marks the node available in the cluster with the specific initial capacity value
+   * @param initialCapability
+   */
+  void markAvailable(long initialCapability);
 
   /**
    * Marks the node unavailable in the cluster if bound.

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/NettyNetworkServer.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/NettyNetworkServer.scala
@@ -38,9 +38,13 @@ class NettyNetworkServer(config: NetworkServerConfig) extends NetworkServer {
 
   def markUnavailable = underlying.markUnavailable
 
+  def markAvailable(initialCapability: Long) = underlying.markAvailable(initialCapability)
+
   def markAvailable = underlying.markAvailable
 
   def getMyNode = underlying.myNode
+
+  def bind(nodeId: Int, markAvailable: Boolean, initialCapacity: Long) = underlying.bind(nodeId, markAvailable, initialCapacity)
 
   def bind(nodeId: Int, markAvailable: Boolean) = underlying.bind(nodeId, markAvailable)
 

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
@@ -57,8 +57,8 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
 
     "throw InvalidClusterException if all partitions are unavailable" in {
       val nodes = Set(
-        Node(0, "localhost:31313", true, Set()),
-        Node(1, "localhost:31313", true, Set()))
+        Node(0, "localhost:31313", true, Set[Int]()),
+        Node(1, "localhost:31313", true, Set[Int]()))
 
       new EIdDefaultLoadBalancerFactory(2, false).newLoadBalancer(toEndpoints(nodes)) must throwA[InvalidClusterException]
     }
@@ -66,7 +66,7 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
     "throw InvalidClusterException if one partition is unavailable, and the LBF cannot serve requests in that state, " in {
       val nodes = Set(
         Node(0, "localhost:31313", true, Set(1)),
-        Node(1, "localhost:31313", true, Set()))
+        Node(1, "localhost:31313", true, Set[Int]()))
 
       new EIdDefaultLoadBalancerFactory(2, true).newLoadBalancer(toEndpoints(nodes)) must not (throwA[InvalidClusterException])
       new EIdDefaultLoadBalancerFactory(2, false).newLoadBalancer(toEndpoints(nodes)) must throwA[InvalidClusterException]
@@ -84,7 +84,7 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
       lb.nodesForPartitionedId(EId(1210)) must haveTheSameElementsAs (Set(Node(0, "localhost:12345", true, Set(0,1,2)),
                                                          Node(3, "localhost:45123", true, Set(3,4,0)),
                                                          Node(4, "localhost:51234", true, Set(4,0,1))))
-    }
+     }
 
     "nodesForPartitionedId returns all nodes regardless if they can serve requests" in {
       val nodes = Set (
@@ -98,6 +98,6 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
       lb.nodesForPartitionedId(EId(1210)) must haveTheSameElementsAs (Set(Node(0, "localhost:12345", true, Set(0,1,2)),
                                                                           Node(3, "localhost:45123", true, Set(3,4,0)),
                                                                           Node(4, "localhost:51234", true, Set(4,0,1))))
-    }
+     }
   }
 }

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerSpec.scala
@@ -73,8 +73,8 @@ class PartitionedConsistentHashedLoadBalancerSpec extends Specification {
 
     "throw InvalidClusterException if all partitions are unavailable" in {
       val nodes = Set(
-        Node(0, "localhost:31313", true, Set()),
-        Node(1, "localhost:31313", true, Set()))
+        Node(0, "localhost:31313", true, Set[Int]()),
+        Node(1, "localhost:31313", true, Set[Int]()))
 
       new TestLBF(2, false).newLoadBalancer(toEndpoints(nodes)) must throwA[InvalidClusterException]
     }
@@ -82,7 +82,7 @@ class PartitionedConsistentHashedLoadBalancerSpec extends Specification {
     "throw InvalidClusterException if one partition is unavailable, and the LBF cannot serve requests in that state, " in {
       val nodes = Set(
         Node(0, "localhost:31313", true, Set(1)),
-        Node(1, "localhost:31313", true, Set()))
+        Node(1, "localhost:31313", true, Set[Int]()))
 
       new TestLBF(2, true).newLoadBalancer(toEndpoints(nodes)) must not (throwA[InvalidClusterException])
       new TestLBF(2, false).newLoadBalancer(toEndpoints(nodes)) must throwA[InvalidClusterException]

--- a/network/src/test/scala/com/linkedin/norbert/network/server/NetworkServerSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/server/NetworkServerSpec.scala
@@ -95,7 +95,7 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
 
         listener.handleClusterEvent(ClusterEvents.Connected(Set()))
 
-        there was one(networkServer.clusterClient).markNodeAvailable(1)
+        there was one(networkServer.clusterClient).markNodeAvailable(1, 0)
       }
 
       "if markAvailable is false, not mark the node available when a Connection message is received" in {
@@ -107,7 +107,7 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
 
         listener.handleClusterEvent(ClusterEvents.Connected(Set()))
 
-        there was no(networkServer.clusterClient).markNodeAvailable(1)
+        there was no(networkServer.clusterClient).markNodeAvailable(1, 0)
       }
     }
 
@@ -128,11 +128,11 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
 
       networkServer.markAvailable
 
-      there was one(networkServer.clusterClient).markNodeAvailable(1)
+      there was one(networkServer.clusterClient).markNodeAvailable(1, 0)
 
       listener.handleClusterEvent(ClusterEvents.Connected(Set()))
 
-      there were two(networkServer.clusterClient).markNodeAvailable(1)
+      there were two(networkServer.clusterClient).markNodeAvailable(1, 0)
     }
 
     "mark the node unavailable and ensure it is not marked available when Connected events are received for markUnavailable" in {
@@ -145,14 +145,14 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
 
       listener.handleClusterEvent(ClusterEvents.Connected(Set()))
 
-      there was one(networkServer.clusterClient).markNodeAvailable(1)
+      there was one(networkServer.clusterClient).markNodeAvailable(1, 0)
 
       networkServer.markUnavailable
 
       listener.handleClusterEvent(ClusterEvents.Connected(Set()))
 
       got {
-        one(networkServer.clusterClient).markNodeAvailable(1)
+        one(networkServer.clusterClient).markNodeAvailable(1, 0)
         one(networkServer.clusterClient).markNodeUnavailable(1)
       }
     }


### PR DESCRIPTION
...orbert can set the capability state via API; norbert keeps track of the capability states of its nodes; Upon startup, norbert takes an optional capability state value to set the state; unit tests
