### PR TITLE
Added capability to NetworkClient (PartitionedNetworkClient), LoadBalancers and its Java Peers

### DIFF
--- a/cluster/src/main/java/com/linkedin/norbert/protos/NorbertProtos.java
+++ b/cluster/src/main/java/com/linkedin/norbert/protos/NorbertProtos.java
@@ -34,6 +34,16 @@ public final class NorbertProtos {
     // optional string error_message = 13;
     boolean hasErrorMessage();
     String getErrorMessage();
+    
+    // repeated .norbert.NorbertMessage.Header header = 14;
+    java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> 
+        getHeaderList();
+    com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header getHeader(int index);
+    int getHeaderCount();
+    java.util.List<? extends com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder> 
+        getHeaderOrBuilderList();
+    com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder getHeaderOrBuilder(
+        int index);
   }
   public static final class NorbertMessage extends
       com.google.protobuf.GeneratedMessage
@@ -133,6 +143,481 @@ public final class NorbertProtos {
       }
       
       // @@protoc_insertion_point(enum_scope:norbert.NorbertMessage.Status)
+    }
+    
+    public interface HeaderOrBuilder
+        extends com.google.protobuf.MessageOrBuilder {
+      
+      // required string key = 1;
+      boolean hasKey();
+      String getKey();
+      
+      // optional string value = 2;
+      boolean hasValue();
+      String getValue();
+    }
+    public static final class Header extends
+        com.google.protobuf.GeneratedMessage
+        implements HeaderOrBuilder {
+      // Use Header.newBuilder() to construct.
+      private Header(Builder builder) {
+        super(builder);
+      }
+      private Header(boolean noInit) {}
+      
+      private static final Header defaultInstance;
+      public static Header getDefaultInstance() {
+        return defaultInstance;
+      }
+      
+      public Header getDefaultInstanceForType() {
+        return defaultInstance;
+      }
+      
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.linkedin.norbert.protos.NorbertProtos.internal_static_norbert_NorbertMessage_Header_descriptor;
+      }
+      
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.linkedin.norbert.protos.NorbertProtos.internal_static_norbert_NorbertMessage_Header_fieldAccessorTable;
+      }
+      
+      private int bitField0_;
+      // required string key = 1;
+      public static final int KEY_FIELD_NUMBER = 1;
+      private Object key_;
+      public boolean hasKey() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public String getKey() {
+        Object ref = key_;
+        if (ref instanceof String) {
+          return (String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          String s = bs.toStringUtf8();
+          if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+            key_ = s;
+          }
+          return s;
+        }
+      }
+      private com.google.protobuf.ByteString getKeyBytes() {
+        Object ref = key_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+          key_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      
+      // optional string value = 2;
+      public static final int VALUE_FIELD_NUMBER = 2;
+      private Object value_;
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public String getValue() {
+        Object ref = value_;
+        if (ref instanceof String) {
+          return (String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          String s = bs.toStringUtf8();
+          if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+            value_ = s;
+          }
+          return s;
+        }
+      }
+      private com.google.protobuf.ByteString getValueBytes() {
+        Object ref = value_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+          value_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      
+      private void initFields() {
+        key_ = "";
+        value_ = "";
+      }
+      private byte memoizedIsInitialized = -1;
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized != -1) return isInitialized == 1;
+        
+        if (!hasKey()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+        memoizedIsInitialized = 1;
+        return true;
+      }
+      
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        getSerializedSize();
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeBytes(1, getKeyBytes());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          output.writeBytes(2, getValueBytes());
+        }
+        getUnknownFields().writeTo(output);
+      }
+      
+      private int memoizedSerializedSize = -1;
+      public int getSerializedSize() {
+        int size = memoizedSerializedSize;
+        if (size != -1) return size;
+      
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeBytesSize(1, getKeyBytes());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeBytesSize(2, getValueBytes());
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSerializedSize = size;
+        return size;
+      }
+      
+      @java.lang.Override
+      protected Object writeReplace() throws java.io.ObjectStreamException {
+        return super.writeReplace();
+      }
+      
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return newBuilder().mergeFrom(data).buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return newBuilder().mergeFrom(data, extensionRegistry)
+                 .buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return newBuilder().mergeFrom(data).buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return newBuilder().mergeFrom(data, extensionRegistry)
+                 .buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return newBuilder().mergeFrom(input).buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return newBuilder().mergeFrom(input, extensionRegistry)
+                 .buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        Builder builder = newBuilder();
+        if (builder.mergeDelimitedFrom(input)) {
+          return builder.buildParsed();
+        } else {
+          return null;
+        }
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        Builder builder = newBuilder();
+        if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+          return builder.buildParsed();
+        } else {
+          return null;
+        }
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return newBuilder().mergeFrom(input).buildParsed();
+      }
+      public static com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return newBuilder().mergeFrom(input, extensionRegistry)
+                 .buildParsed();
+      }
+      
+      public static Builder newBuilder() { return Builder.create(); }
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder(com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header prototype) {
+        return newBuilder().mergeFrom(prototype);
+      }
+      public Builder toBuilder() { return newBuilder(this); }
+      
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessage.Builder<Builder>
+         implements com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return com.linkedin.norbert.protos.NorbertProtos.internal_static_norbert_NorbertMessage_Header_descriptor;
+        }
+        
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return com.linkedin.norbert.protos.NorbertProtos.internal_static_norbert_NorbertMessage_Header_fieldAccessorTable;
+        }
+        
+        // Construct using com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+        
+        private Builder(BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          }
+        }
+        private static Builder create() {
+          return new Builder();
+        }
+        
+        public Builder clear() {
+          super.clear();
+          key_ = "";
+          bitField0_ = (bitField0_ & ~0x00000001);
+          value_ = "";
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+        
+        public Builder clone() {
+          return create().mergeFrom(buildPartial());
+        }
+        
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.getDescriptor();
+        }
+        
+        public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header getDefaultInstanceForType() {
+          return com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.getDefaultInstance();
+        }
+        
+        public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header build() {
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+        
+        private com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header buildParsed()
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(
+              result).asInvalidProtocolBufferException();
+          }
+          return result;
+        }
+        
+        public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header buildPartial() {
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header result = new com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.key_ = key_;
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          result.value_ = value_;
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+        
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header) {
+            return mergeFrom((com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+        
+        public Builder mergeFrom(com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header other) {
+          if (other == com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.getDefaultInstance()) return this;
+          if (other.hasKey()) {
+            setKey(other.getKey());
+          }
+          if (other.hasValue()) {
+            setValue(other.getValue());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          return this;
+        }
+        
+        public final boolean isInitialized() {
+          if (!hasKey()) {
+            
+            return false;
+          }
+          return true;
+        }
+        
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder(
+              this.getUnknownFields());
+          while (true) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                this.setUnknownFields(unknownFields.build());
+                onChanged();
+                return this;
+              default: {
+                if (!parseUnknownField(input, unknownFields,
+                                       extensionRegistry, tag)) {
+                  this.setUnknownFields(unknownFields.build());
+                  onChanged();
+                  return this;
+                }
+                break;
+              }
+              case 10: {
+                bitField0_ |= 0x00000001;
+                key_ = input.readBytes();
+                break;
+              }
+              case 18: {
+                bitField0_ |= 0x00000002;
+                value_ = input.readBytes();
+                break;
+              }
+            }
+          }
+        }
+        
+        private int bitField0_;
+        
+        // required string key = 1;
+        private Object key_ = "";
+        public boolean hasKey() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        public String getKey() {
+          Object ref = key_;
+          if (!(ref instanceof String)) {
+            String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
+            key_ = s;
+            return s;
+          } else {
+            return (String) ref;
+          }
+        }
+        public Builder setKey(String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+          key_ = value;
+          onChanged();
+          return this;
+        }
+        public Builder clearKey() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          key_ = getDefaultInstance().getKey();
+          onChanged();
+          return this;
+        }
+        void setKey(com.google.protobuf.ByteString value) {
+          bitField0_ |= 0x00000001;
+          key_ = value;
+          onChanged();
+        }
+        
+        // optional string value = 2;
+        private Object value_ = "";
+        public boolean hasValue() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        public String getValue() {
+          Object ref = value_;
+          if (!(ref instanceof String)) {
+            String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
+            value_ = s;
+            return s;
+          } else {
+            return (String) ref;
+          }
+        }
+        public Builder setValue(String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          value_ = value;
+          onChanged();
+          return this;
+        }
+        public Builder clearValue() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          value_ = getDefaultInstance().getValue();
+          onChanged();
+          return this;
+        }
+        void setValue(com.google.protobuf.ByteString value) {
+          bitField0_ |= 0x00000002;
+          value_ = value;
+          onChanged();
+        }
+        
+        // @@protoc_insertion_point(builder_scope:norbert.NorbertMessage.Header)
+      }
+      
+      static {
+        defaultInstance = new Header(true);
+        defaultInstance.initFields();
+      }
+      
+      // @@protoc_insertion_point(class_scope:norbert.NorbertMessage.Header)
     }
     
     private int bitField0_;
@@ -240,6 +725,27 @@ public final class NorbertProtos {
       }
     }
     
+    // repeated .norbert.NorbertMessage.Header header = 14;
+    public static final int HEADER_FIELD_NUMBER = 14;
+    private java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> header_;
+    public java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> getHeaderList() {
+      return header_;
+    }
+    public java.util.List<? extends com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder> 
+        getHeaderOrBuilderList() {
+      return header_;
+    }
+    public int getHeaderCount() {
+      return header_.size();
+    }
+    public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header getHeader(int index) {
+      return header_.get(index);
+    }
+    public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder getHeaderOrBuilder(
+        int index) {
+      return header_.get(index);
+    }
+    
     private void initFields() {
       requestIdMsb_ = 0L;
       requestIdLsb_ = 0L;
@@ -247,6 +753,7 @@ public final class NorbertProtos {
       messageName_ = "";
       message_ = com.google.protobuf.ByteString.EMPTY;
       errorMessage_ = "";
+      header_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -264,6 +771,12 @@ public final class NorbertProtos {
       if (!hasMessageName()) {
         memoizedIsInitialized = 0;
         return false;
+      }
+      for (int i = 0; i < getHeaderCount(); i++) {
+        if (!getHeader(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
       }
       memoizedIsInitialized = 1;
       return true;
@@ -289,6 +802,9 @@ public final class NorbertProtos {
       }
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeBytes(13, getErrorMessageBytes());
+      }
+      for (int i = 0; i < header_.size(); i++) {
+        output.writeMessage(14, header_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -322,6 +838,10 @@ public final class NorbertProtos {
       if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(13, getErrorMessageBytes());
+      }
+      for (int i = 0; i < header_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(14, header_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -437,6 +957,7 @@ public final class NorbertProtos {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getHeaderFieldBuilder();
         }
       }
       private static Builder create() {
@@ -457,6 +978,12 @@ public final class NorbertProtos {
         bitField0_ = (bitField0_ & ~0x00000010);
         errorMessage_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
+        if (headerBuilder_ == null) {
+          header_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000040);
+        } else {
+          headerBuilder_.clear();
+        }
         return this;
       }
       
@@ -519,6 +1046,15 @@ public final class NorbertProtos {
           to_bitField0_ |= 0x00000020;
         }
         result.errorMessage_ = errorMessage_;
+        if (headerBuilder_ == null) {
+          if (((bitField0_ & 0x00000040) == 0x00000040)) {
+            header_ = java.util.Collections.unmodifiableList(header_);
+            bitField0_ = (bitField0_ & ~0x00000040);
+          }
+          result.header_ = header_;
+        } else {
+          result.header_ = headerBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -553,6 +1089,32 @@ public final class NorbertProtos {
         if (other.hasErrorMessage()) {
           setErrorMessage(other.getErrorMessage());
         }
+        if (headerBuilder_ == null) {
+          if (!other.header_.isEmpty()) {
+            if (header_.isEmpty()) {
+              header_ = other.header_;
+              bitField0_ = (bitField0_ & ~0x00000040);
+            } else {
+              ensureHeaderIsMutable();
+              header_.addAll(other.header_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.header_.isEmpty()) {
+            if (headerBuilder_.isEmpty()) {
+              headerBuilder_.dispose();
+              headerBuilder_ = null;
+              header_ = other.header_;
+              bitField0_ = (bitField0_ & ~0x00000040);
+              headerBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getHeaderFieldBuilder() : null;
+            } else {
+              headerBuilder_.addAllMessages(other.header_);
+            }
+          }
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -569,6 +1131,12 @@ public final class NorbertProtos {
         if (!hasMessageName()) {
           
           return false;
+        }
+        for (int i = 0; i < getHeaderCount(); i++) {
+          if (!getHeader(i).isInitialized()) {
+            
+            return false;
+          }
         }
         return true;
       }
@@ -630,6 +1198,12 @@ public final class NorbertProtos {
             case 106: {
               bitField0_ |= 0x00000020;
               errorMessage_ = input.readBytes();
+              break;
+            }
+            case 114: {
+              com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder subBuilder = com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addHeader(subBuilder.buildPartial());
               break;
             }
           }
@@ -798,6 +1372,192 @@ public final class NorbertProtos {
         bitField0_ |= 0x00000020;
         errorMessage_ = value;
         onChanged();
+      }
+      
+      // repeated .norbert.NorbertMessage.Header header = 14;
+      private java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> header_ =
+        java.util.Collections.emptyList();
+      private void ensureHeaderIsMutable() {
+        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
+          header_ = new java.util.ArrayList<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header>(header_);
+          bitField0_ |= 0x00000040;
+         }
+      }
+      
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder> headerBuilder_;
+      
+      public java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> getHeaderList() {
+        if (headerBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(header_);
+        } else {
+          return headerBuilder_.getMessageList();
+        }
+      }
+      public int getHeaderCount() {
+        if (headerBuilder_ == null) {
+          return header_.size();
+        } else {
+          return headerBuilder_.getCount();
+        }
+      }
+      public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header getHeader(int index) {
+        if (headerBuilder_ == null) {
+          return header_.get(index);
+        } else {
+          return headerBuilder_.getMessage(index);
+        }
+      }
+      public Builder setHeader(
+          int index, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header value) {
+        if (headerBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureHeaderIsMutable();
+          header_.set(index, value);
+          onChanged();
+        } else {
+          headerBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      public Builder setHeader(
+          int index, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder builderForValue) {
+        if (headerBuilder_ == null) {
+          ensureHeaderIsMutable();
+          header_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          headerBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addHeader(com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header value) {
+        if (headerBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureHeaderIsMutable();
+          header_.add(value);
+          onChanged();
+        } else {
+          headerBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      public Builder addHeader(
+          int index, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header value) {
+        if (headerBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureHeaderIsMutable();
+          header_.add(index, value);
+          onChanged();
+        } else {
+          headerBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      public Builder addHeader(
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder builderForValue) {
+        if (headerBuilder_ == null) {
+          ensureHeaderIsMutable();
+          header_.add(builderForValue.build());
+          onChanged();
+        } else {
+          headerBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addHeader(
+          int index, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder builderForValue) {
+        if (headerBuilder_ == null) {
+          ensureHeaderIsMutable();
+          header_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          headerBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      public Builder addAllHeader(
+          java.lang.Iterable<? extends com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header> values) {
+        if (headerBuilder_ == null) {
+          ensureHeaderIsMutable();
+          super.addAll(values, header_);
+          onChanged();
+        } else {
+          headerBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      public Builder clearHeader() {
+        if (headerBuilder_ == null) {
+          header_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000040);
+          onChanged();
+        } else {
+          headerBuilder_.clear();
+        }
+        return this;
+      }
+      public Builder removeHeader(int index) {
+        if (headerBuilder_ == null) {
+          ensureHeaderIsMutable();
+          header_.remove(index);
+          onChanged();
+        } else {
+          headerBuilder_.remove(index);
+        }
+        return this;
+      }
+      public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder getHeaderBuilder(
+          int index) {
+        return getHeaderFieldBuilder().getBuilder(index);
+      }
+      public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder getHeaderOrBuilder(
+          int index) {
+        if (headerBuilder_ == null) {
+          return header_.get(index);  } else {
+          return headerBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      public java.util.List<? extends com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder> 
+           getHeaderOrBuilderList() {
+        if (headerBuilder_ != null) {
+          return headerBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(header_);
+        }
+      }
+      public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder addHeaderBuilder() {
+        return getHeaderFieldBuilder().addBuilder(
+            com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.getDefaultInstance());
+      }
+      public com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder addHeaderBuilder(
+          int index) {
+        return getHeaderFieldBuilder().addBuilder(
+            index, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.getDefaultInstance());
+      }
+      public java.util.List<com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder> 
+           getHeaderBuilderList() {
+        return getHeaderFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder> 
+          getHeaderFieldBuilder() {
+        if (headerBuilder_ == null) {
+          headerBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder, com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.HeaderOrBuilder>(
+                  header_,
+                  ((bitField0_ & 0x00000040) == 0x00000040),
+                  getParentForChildren(),
+                  isClean());
+          header_ = null;
+        }
+        return headerBuilder_;
       }
       
       // @@protoc_insertion_point(builder_scope:norbert.NorbertMessage)
@@ -1371,6 +2131,11 @@ public final class NorbertProtos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_norbert_NorbertMessage_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_norbert_NorbertMessage_Header_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_norbert_NorbertMessage_Header_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_norbert_Node_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -1384,15 +2149,17 @@ public final class NorbertProtos {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\rnorbert.proto\022\007norbert\"\336\001\n\016NorbertMess" +
+      "\n\rnorbert.proto\022\007norbert\"\264\002\n\016NorbertMess" +
       "age\022\026\n\016request_id_msb\030\001 \002(\020\022\026\n\016request_i" +
       "d_lsb\030\002 \002(\020\0222\n\006status\030\n \001(\0162\036.norbert.No" +
       "rbertMessage.Status:\002OK\022\024\n\014message_name\030" +
       "\013 \002(\t\022\017\n\007message\030\014 \001(\014\022\025\n\rerror_message\030" +
-      "\r \001(\t\"*\n\006Status\022\006\n\002OK\020\000\022\t\n\005ERROR\020\001\022\r\n\tHE" +
-      "AVYLOAD\020\002\"2\n\004Node\022\n\n\002id\030\001 \002(\005\022\013\n\003url\030\002 \002" +
-      "(\t\022\021\n\tpartition\030\003 \003(\005B.\n\033com.linkedin.no" +
-      "rbert.protosB\rNorbertProtosH\001"
+      "\r \001(\t\022.\n\006header\030\016 \003(\0132\036.norbert.NorbertM" +
+      "essage.Header\032$\n\006Header\022\013\n\003key\030\001 \002(\t\022\r\n\005" +
+      "value\030\002 \001(\t\"*\n\006Status\022\006\n\002OK\020\000\022\t\n\005ERROR\020\001" +
+      "\022\r\n\tHEAVYLOAD\020\002\"2\n\004Node\022\n\n\002id\030\001 \002(\005\022\013\n\003u" +
+      "rl\030\002 \002(\t\022\021\n\tpartition\030\003 \003(\005B.\n\033com.linke",
+      "din.norbert.protosB\rNorbertProtosH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -1404,9 +2171,17 @@ public final class NorbertProtos {
           internal_static_norbert_NorbertMessage_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_norbert_NorbertMessage_descriptor,
-              new java.lang.String[] { "RequestIdMsb", "RequestIdLsb", "Status", "MessageName", "Message", "ErrorMessage", },
+              new java.lang.String[] { "RequestIdMsb", "RequestIdLsb", "Status", "MessageName", "Message", "ErrorMessage", "Header", },
               com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.class,
               com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Builder.class);
+          internal_static_norbert_NorbertMessage_Header_descriptor =
+            internal_static_norbert_NorbertMessage_descriptor.getNestedTypes().get(0);
+          internal_static_norbert_NorbertMessage_Header_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_norbert_NorbertMessage_Header_descriptor,
+              new java.lang.String[] { "Key", "Value", },
+              com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.class,
+              com.linkedin.norbert.protos.NorbertProtos.NorbertMessage.Header.Builder.class);
           internal_static_norbert_Node_descriptor =
             getDescriptor().getMessageTypes().get(1);
           internal_static_norbert_Node_fieldAccessorTable = new

--- a/cluster/src/main/protobuf/norbert.proto
+++ b/cluster/src/main/protobuf/norbert.proto
@@ -18,6 +18,12 @@ message NorbertMessage {
   required string message_name = 11;
   optional bytes message = 12;
   optional string error_message = 13;
+
+  message Header {
+    required string key = 1;
+    optional string value = 2;
+  }
+  repeated Header header = 14;
 }
 
 message Node {

--- a/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/cluster/Node.scala
@@ -84,4 +84,12 @@ final case class Node(id: Int, url: String, available: Boolean, partitionIds: Se
   }
 
   override def toString = "Node(%d,%s,[%s],%b,0x%08X)".format(id, url, partitionIds.mkString(","), available, if (capability.isEmpty) 0L else capability.get)
+
+  def isCapableOf(c: Option[Long]) : Boolean = {
+    (capability, c) match {
+      case (Some(nc), Some(rc)) => (nc & rc) == rc
+      case (None, Some(rc)) => rc == 0L
+      case _ => true
+    }
+  }
 }

--- a/examples/src/main/java/com/linkedin/norbert/javacompat/network/RunNorbertSetup.java
+++ b/examples/src/main/java/com/linkedin/norbert/javacompat/network/RunNorbertSetup.java
@@ -44,6 +44,12 @@ public class RunNorbertSetup
                     {
                         return endpoints.iterator().next().getNode();
                     }
+
+                    @java.lang.Override
+                    public Node nextNode(Long capability)
+                    {
+                      return endpoints.iterator().next().getNode();
+                    }
                 };
             }
         };

--- a/examples/src/main/scala/com/linkedin/norbert/network/NorbertNetworkClientMain.scala
+++ b/examples/src/main/scala/com/linkedin/norbert/network/NorbertNetworkClientMain.scala
@@ -99,8 +99,8 @@ object NorbertNetworkClientMain {
             case Some(n) =>
               val future = nc.sendRequestToNode(Ping(System.currentTimeMillis), n)
               try {
-                val response = future.get(500, TimeUnit.MILLISECONDS).asInstanceOf[NorbertExampleProtos.PingResponse]
-                println("Ping took %dms".format(System.currentTimeMillis - response.getTimestamp))
+                val response = future.get(500, TimeUnit.MILLISECONDS).asInstanceOf[Pong]
+                println("Ping took %dms".format(System.currentTimeMillis - response.timestamp))
               } catch {
                 case ex: TimeoutException => println("Ping timed out")
                 case ex: ExecutionException => println("Error: %s".format(ex.getCause))

--- a/examples/src/main/scala/com/linkedin/norbert/network/PingRequest.scala
+++ b/examples/src/main/scala/com/linkedin/norbert/network/PingRequest.scala
@@ -18,7 +18,7 @@ package com.linkedin.norbert.network
 import com.linkedin.norbert.protos.NorbertExampleProtos
 
 object Ping {
-  implicit case object PingSerializer extends Serializer[Ping, Ping] {
+  implicit case object PingSerializer extends Serializer[Ping,  Pong] {
     def requestName = "ping"
     def responseName = "pong"
 
@@ -29,12 +29,13 @@ object Ping {
       Ping(NorbertExampleProtos.Ping.newBuilder.mergeFrom(bytes).build.getTimestamp)
     }
 
-    def responseToBytes(message: Ping) =
-      requestToBytes(message)
+    def responseToBytes(message: Pong) =
+      NorbertExampleProtos.PingResponse.newBuilder.setTimestamp(message.timestamp).build.toByteArray
 
     def responseFromBytes(bytes: Array[Byte]) =
-      requestFromBytes(bytes)
+      Pong(NorbertExampleProtos.PingResponse.newBuilder.mergeFrom(bytes).build.getTimestamp)
   }
 }
 
 case class Ping(timestamp: Long)
+case class Pong(timestamp: Long)

--- a/java-cluster/src/main/java/com/linkedin/norbert/javacompat/cluster/Node.java
+++ b/java-cluster/src/main/java/com/linkedin/norbert/javacompat/cluster/Node.java
@@ -22,4 +22,5 @@ public interface Node {
   String getUrl();
   Set<Integer> getPartitionIds();
   boolean isAvailable();
+  boolean isCapableOf(Long c);
 }

--- a/java-cluster/src/main/scala/com/linkedin/norbert/javacompat/cluster/JavaNode.scala
+++ b/java-cluster/src/main/scala/com/linkedin/norbert/javacompat/cluster/JavaNode.scala
@@ -27,11 +27,16 @@ object JavaNode {
       if (node.partitionIds != null) {
         node.partitionIds.foreach {id => s.add(id)}
       }
-      JavaNode(node.id, node.url, node.available, s)
+      JavaNode(node.id, node.url, node.available, s, node.capability)
     }
   }
 }
 
-case class JavaNode(@BeanProperty id: Int, @BeanProperty url: String, @BeanProperty available: Boolean, @BeanProperty partitionIds: java.util.Set[java.lang.Integer]) extends Node {
+case class JavaNode(@BeanProperty id: Int, @BeanProperty url: String, @BeanProperty available: Boolean, @BeanProperty partitionIds: java.util.Set[java.lang.Integer], capability: Option[Long]) extends Node {
   def isAvailable = available
+  def isCapableOf(c: java.lang.Long) : Boolean =
+    capability match {
+      case Some(nc) => (nc & c.longValue) == c.longValue
+      case None => c.longValue == 0L
+    }
 }

--- a/java-network/src/main/java/com/linkedin/norbert/javacompat/network/LoadBalancer.java
+++ b/java-network/src/main/java/com/linkedin/norbert/javacompat/network/LoadBalancer.java
@@ -27,4 +27,12 @@ public interface LoadBalancer {
    * @return the <code>Node</code> to route the next request to or null if there are no <code>Node</code>s available
    */
   Node nextNode();
+
+  /**
+   * Returns the next <code>Node</code> that fulfill the capability a request should be routed to.
+   *
+   * @param capability A Long that representing the minimal capability of the node that's serving the request
+   * @return the <code>Node</code> to route the next request to or null if there are no <code>Node</code>'s available
+   */
+  Node nextNode(Long capability);
 }

--- a/java-network/src/main/java/com/linkedin/norbert/javacompat/network/PartitionedLoadBalancer.java
+++ b/java-network/src/main/java/com/linkedin/norbert/javacompat/network/PartitionedLoadBalancer.java
@@ -17,11 +17,16 @@ package com.linkedin.norbert.javacompat.network;
 
 import java.util.Map;
 import java.util.Set;
+import java.lang.Long;
 import com.linkedin.norbert.javacompat.cluster.Node;
 
 /**
  * A <code>PartitionedLoadBalancer</code> handles calculating the next <code>Node</code> a message should be routed to
  * based on a PartitionedId.
+ *
+ * Each of these API have two versions, one without capability long, one with it. The capability long is a piece of data
+ * held by Norbert node representing 64 different capability by setting each bit of the Long. If the API takes a capability
+ * parameter, load balancer will only return nodes satisfying the at least the capability requested.
  */
 public interface PartitionedLoadBalancer<PartitionedId> {
   /**
@@ -34,10 +39,26 @@ public interface PartitionedLoadBalancer<PartitionedId> {
   Node nextNode(PartitionedId id);
 
   /**
+   * Returns the next <code>Node</code> a message should be routed to based on the PartitionId provided.
+   *
+   * @param id the id to be used to calculate partitioning information.
+   * @param capability the minimal capability required by client
+   *
+   * @return the <code>Node</code> to route the next message to
+   */
+  Node nextNode(PartitionedId id, Long capability);
+
+  /**
    * Returns all replica nodes for the same partitionedId
    * @return the <code>Nodes</code> to multicast the next messages to each replica
    */
   Set<Node> nodesForPartitionedId(PartitionedId id);
+
+  /**
+   * Returns all replica nodes for the same partitionedId
+   * @return the <code>Nodes</code> to multicast the next messages to each replica
+   */
+  Set<Node> nodesForPartitionedId(PartitionedId id, Long capability);
 
   /**
    * Returns a set of nodes represents one replica of the cluster, this is used by the PartitionedNetworkClient to handle
@@ -48,10 +69,26 @@ public interface PartitionedLoadBalancer<PartitionedId> {
   Map<Node, Set<Integer>> nodesForOneReplica(PartitionedId id);
 
   /**
+   * Returns a set of nodes represents one replica of the cluster, this is used by the PartitionedNetworkClient to handle
+   * broadcast to one replica
+   *
+   * @return the set of <code>Nodes</code> to broadcast the next message to a replica to
+   */
+  Map<Node, Set<Integer>> nodesForOneReplica(PartitionedId id, Long capability);
+
+  /**
    * Calculates a mapping of nodes to partitions for broadcasting a partitioned request. Optionally uses a partitioned
    * id for consistent hashing purposes
    *
    * @return the <code>Nodes</code> to broadcast the next message to a replica to
    */
   Map<Node, Set<Integer>> nodesForPartitions(PartitionedId id, Set<Integer> partitions);
+
+  /**
+   * Calculates a mapping of nodes to partitions for broadcasting a partitioned request. Optionally uses a partitioned
+   * id for consistent hashing purposes
+   *
+   * @return the <code>Nodes</code> to broadcast the next message to a replica to
+   */
+  Map<Node, Set<Integer>> nodesForPartitions(PartitionedId id, Set<Integer> partitions, Long capability);
 }

--- a/java-network/src/main/java/com/linkedin/norbert/javacompat/network/RingHashPartitionedLoadBalancer.java
+++ b/java-network/src/main/java/com/linkedin/norbert/javacompat/network/RingHashPartitionedLoadBalancer.java
@@ -46,6 +46,11 @@ public class RingHashPartitionedLoadBalancer implements PartitionedLoadBalancer<
   }
 
   public Node nextNode(Integer partitionedId) {
+    return nextNode(partitionedId, 0L);
+  }
+
+  @Override
+  public Node nextNode(Integer partitionedId, Long capability) {
     if (nodeCircleMap.isEmpty())
       return null;
 
@@ -58,7 +63,7 @@ public class RingHashPartitionedLoadBalancer implements PartitionedLoadBalancer<
 
     do {
       Node node = endpoint.getNode();
-      if(endpoint.canServeRequests()) {
+      if(endpoint.canServeRequests() && node.isCapableOf(capability)) {
         if (log.isDebugEnabled())
           log.debug(partitionedId + " is sent to node " + node.getId());
         return node;
@@ -74,19 +79,34 @@ public class RingHashPartitionedLoadBalancer implements PartitionedLoadBalancer<
     log.warn("All endpoints seem unavailable! Using the default");
     return firstEndpoint.getNode();
   }
-
+  
   @Override
   public Set<Node> nodesForPartitionedId(Integer partitionedId) {
     throw new UnsupportedOperationException();
   }
-
+  
+  @Override
+  public Set<Node> nodesForPartitionedId(Integer partitionedId, Long capability) {
+    throw new UnsupportedOperationException();
+  }
+  
   @Override
   public Map<Node, Set<Integer>> nodesForOneReplica(Integer partitionedId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
+  public Map<Node, Set<Integer>> nodesForOneReplica(Integer partitionedId, Long capability) {
+    throw new UnsupportedOperationException();
+  }
+  
+  @Override
   public Map<Node, Set<Integer>> nodesForPartitions(Integer integer, Set<Integer> partitions) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<Node, Set<Integer>> nodesForPartitions(Integer integer, Set<Integer> partitions, Long capability) {
     throw new UnsupportedOperationException();
   }
 }

--- a/java-network/src/main/java/com/linkedin/norbert/javacompat/network/RoundRobinLoadBalancerFactory.java
+++ b/java-network/src/main/java/com/linkedin/norbert/javacompat/network/RoundRobinLoadBalancerFactory.java
@@ -20,6 +20,7 @@ import com.linkedin.norbert.cluster.InvalidClusterException;
 import com.linkedin.norbert.javacompat.cluster.JavaNode;
 import com.linkedin.norbert.javacompat.cluster.Node;
 import scala.Option;
+import scala.Some;
 
 import java.util.Set;
 
@@ -35,12 +36,18 @@ public class RoundRobinLoadBalancerFactory implements LoadBalancerFactory {
       return new LoadBalancer() {
         @Override
         public Node nextNode() {
-          Option<com.linkedin.norbert.cluster.Node> node = loadBalancer.nextNode();
+          return nextNode(0L);
+        }
+
+        @Override
+        public Node nextNode(Long capability){
+          Option<com.linkedin.norbert.cluster.Node> node = loadBalancer.nextNode(new Some<Long>(capability.longValue()));
           if(node.isDefined())
             return JavaNode.apply(node.get());
           else
             return null;
         }
+
       };
     }
 }

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/BaseNettyNetworkClient.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/BaseNettyNetworkClient.scala
@@ -70,7 +70,10 @@ class NettyNetworkClient(config: NetworkClientConfig, loadBalancerFactory: LoadB
     def newLoadBalancer(endpoints: Set[SEndpoint]) = new SLoadBalancer {
       private val lb = loadBalancerFactory.newLoadBalancer(endpoints)
 
-      def nextNode = Option(lb.nextNode)
+      def nextNode(capability: Option[Long]) = Option(capability match {
+                                                        case Some(c) => lb.nextNode(c.longValue)
+                                                        case None => lb.nextNode
+                                                      })
     }
   }
 

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/DefaultPartitionedLoadBalancerFactory.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/DefaultPartitionedLoadBalancerFactory.scala
@@ -34,7 +34,7 @@ abstract class DefaultPartitionedLoadBalancerFactory[PartitionedId]
 (numPartitions: Int, serveRequestsIfPartitionMissing: Boolean = true) extends PartitionedLoadBalancerFactory[PartitionedId] {
   def this(numPartitions: Int) = this(numPartitions, true)
   
-  val underlying = new SDefaultPartitionedLoadBalancerFactory[PartitionedId](serveRequestsIfPartitionMissing) {
+  val underlying = new SDefaultPartitionedLoadBalancerFactory[PartitionedId](numPartitions, serveRequestsIfPartitionMissing) {
     protected def calculateHash(id: PartitionedId) = hashPartitionedId(id)
 
     def getNumPartitions(endpoints: Set[SEndpoint]) = {

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/JavaLbfToScalaLbf.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/JavaLbfToScalaLbf.scala
@@ -14,12 +14,18 @@ class JavaLbfToScalaLbf[PartitionedId](javaLbf: PartitionedLoadBalancerFactory[P
   def newLoadBalancer(nodes: Set[SEndpoint]) = {
     val lb = javaLbf.newLoadBalancer(nodes)
     new SPartitionedLoadBalancer[PartitionedId] {
-      def nextNode(id: PartitionedId) = {
-        Option(lb.nextNode(id))
+      def nextNode(id: PartitionedId, capability: Option[Long] = None) = {
+        capability match {
+          case Some(c) => Option(lb.nextNode(id, c.longValue))
+          case None => Option(lb.nextNode(id))
+        }
       }
 
-      def nodesForOneReplica(id: PartitionedId) = {
-        val jMap = lb.nodesForOneReplica(id)
+      def nodesForOneReplica(id: PartitionedId, capability: Option[Long]  = None) = {
+        val jMap = capability match {
+          case Some(c) => lb.nodesForOneReplica(id, c.longValue)
+          case None => lb.nodesForOneReplica(id)
+        }
         var sMap = Map.empty[com.linkedin.norbert.cluster.Node, Set[Int]]
 
         val entries = jMap.entrySet.iterator
@@ -33,8 +39,11 @@ class JavaLbfToScalaLbf[PartitionedId](javaLbf: PartitionedLoadBalancerFactory[P
         sMap
       }
 
-      def nodesForPartitionedId(id: PartitionedId) = {
-        val jSet = lb.nodesForPartitionedId(id)
+      def nodesForPartitionedId(id: PartitionedId, capability: Option[Long] = None) = {
+        val jSet = capability match {
+          case Some(c) => lb.nodesForPartitionedId(id, c.longValue)
+          case None => lb.nodesForPartitionedId(id)
+        }
         var sSet = Set.empty[SNode]
         val entries = jSet.iterator
         while(entries.hasNext) {
@@ -44,8 +53,11 @@ class JavaLbfToScalaLbf[PartitionedId](javaLbf: PartitionedLoadBalancerFactory[P
         sSet
       }
 
-      def nodesForPartitions(id: PartitionedId, partitions: Set[Int]) = {
-        val jMap = lb.nodesForOneReplica(id)
+      def nodesForPartitions(id: PartitionedId, partitions: Set[Int], capability: Option[Long] = None) = {
+        val jMap =  capability match {
+          case Some(c) => lb.nodesForOneReplica(id, c.longValue)
+          case None => lb.nodesForOneReplica(id)
+        }
         var sMap = Map.empty[com.linkedin.norbert.cluster.Node, Set[Int]]
 
         val entries = jMap.entrySet.iterator

--- a/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/ScalaLbfToJavaLbf.scala
+++ b/java-network/src/main/scala/com/linkedin/norbert/javacompat/network/ScalaLbfToJavaLbf.scala
@@ -4,7 +4,9 @@ package network
 
 import com.linkedin.norbert.network.partitioned.loadbalancer.{PartitionedLoadBalancerFactory => SPartitionedLoadBalancerFactory}
 import com.linkedin.norbert.EndpointConversions._
-import cluster.Node
+import javacompat.cluster.Node
+import javacompat._
+
 
 class ScalaLbfToJavaLbf[PartitionedId](scalaLbf: SPartitionedLoadBalancerFactory[PartitionedId]) extends PartitionedLoadBalancerFactory[PartitionedId] {
 
@@ -12,42 +14,57 @@ class ScalaLbfToJavaLbf[PartitionedId](scalaLbf: SPartitionedLoadBalancerFactory
     val scalaBalancer = scalaLbf.newLoadBalancer(endpoints)
 
     new PartitionedLoadBalancer[PartitionedId] {
-      def nodesForOneReplica(id: PartitionedId) = {
-        val replica = scalaBalancer.nodesForOneReplica(id)
+      def nodesForOneReplica(id: PartitionedId) = nodesForOneReplica(id, 0L)
+
+      def nodesForOneReplica(id: PartitionedId, capability: java.lang.Long) = {
+        val replica = scalaBalancer.nodesForOneReplica(id, capability)
         val result = new java.util.HashMap[Node, java.util.Set[java.lang.Integer]](replica.size)
-        
+
         replica.foreach { case (node, partitions) =>
           result.put(node, partitions)
-        }
+                        }
 
-        result
+        result        
       }
 
-      def nextNode(id: PartitionedId) = {
-        scalaBalancer.nextNode(id) match {
-          case Some(n) => n
+      def nextNode(id: PartitionedId) = nextNode(id, 0L)
+
+      def nextNode(id: PartitionedId, capability: java.lang.Long) =  {
+        scalaBalancer.nextNode(id, capability) match {
+          case Some(n) =>n
           case None => null
         }
       }
 
-      def nodesForPartitionedId(id: PartitionedId) = {
-        val set = scalaBalancer.nodesForPartitionedId(id)
+      def nodesForPartitionedId(id: PartitionedId) = nodesForPartitionedId(id, 0L)
+
+      def nodesForPartitionedId(id: PartitionedId, capability: java.lang.Long) = {
+        val set = scalaBalancer.nodesForPartitionedId(id, capability)
         val jSet = new java.util.HashSet[Node]()
         set.foldLeft(jSet) { case (jSet, node) => {jSet.add(node); jSet} }
         jSet
       }
 
-      def nodesForPartitions(id: PartitionedId, partitions: java.util.Set[java.lang.Integer]) = {
-        val replica = scalaBalancer.nodesForPartitions(id, partitions)
+      def nodesForPartitions(id: PartitionedId, partitions: java.util.Set[java.lang.Integer]) = nodesForPartitions(id, partitions, 0L)
+
+      def nodesForPartitions(id: PartitionedId, partitions:java.util.Set[java.lang.Integer], capability: java.lang.Long) =  {
+        val replica = scalaBalancer.nodesForPartitions(id, partitions, capability)
         val result = new java.util.HashMap[Node, java.util.Set[java.lang.Integer]](replica.size)
 
         replica.foreach { case (node, partitions) =>
           result.put(node, partitions)
-        }
+                        }
 
         result
       }
+
+      implicit def toOption(capability: java.lang.Long) : Option[Long] = {
+        if (capability.longValue == 0L) None
+        else Some(capability.longValue)
+      }
     }
+    
+
   }
 
   def getNumPartitions(endpoints: java.util.Set[Endpoint]) = {

--- a/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/LoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/LoadBalancerFactory.scala
@@ -31,8 +31,17 @@ trait LoadBalancer {
    * @return the <code>Some(node)</code> to route the next message to or <code>None</code> if there are no <code>Node</code>s
    * available
    */
-  def nextNode: Option[Node]
+  def nextNode: Option[Node] = nextNode(None)
+
+  /**
+   * Returns the next <code>Node</code> that serving the capability value if not None a message should be routed to.
+   * @param capability
+   * @return the <code>Some(node)</code> to route the next message to or <code>None</code> if there are no <code>Node</code>'s
+   * available;
+   */
+  def nextNode(capability : Option[Long] = None): Option[Node]
 }
+
 
 /**
  * A factory which can generate <code>LoadBalancer</code>s.

--- a/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactory.scala
@@ -29,8 +29,8 @@ class RoundRobinLoadBalancerFactory extends LoadBalancerFactory with LoadBalance
     val counter = new AtomicInteger(0)
     val endpoints = endpointSet.toArray
 
-    def nextNode = {
-      val activeEndpoints = endpoints.filter(_.canServeRequests)
+    def nextNode(capability: Option[Long] = None) = {
+      val activeEndpoints = endpoints.filter{ (e : Endpoint) => e.canServeRequests && e.node.isCapableOf(capability) }
 
       if(activeEndpoints.isEmpty)
         Some(chooseNext(endpoints, counter).node)
@@ -39,5 +39,7 @@ class RoundRobinLoadBalancerFactory extends LoadBalancerFactory with LoadBalance
       else
         Some(chooseNext(activeEndpoints, counter).node)
     }
+
+
   }
 }

--- a/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactory.scala
@@ -33,7 +33,7 @@ class RoundRobinLoadBalancerFactory extends LoadBalancerFactory with LoadBalance
       val activeEndpoints = endpoints.filter{ (e : Endpoint) => e.canServeRequests && e.node.isCapableOf(capability) }
 
       if(activeEndpoints.isEmpty)
-        Some(chooseNext(endpoints, counter).node)
+        Some(chooseNext(endpoints.filter(_.node.isCapableOf(capability)), counter).node)
       else if(endpoints.isEmpty)
         None
       else

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/Filter.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/Filter.scala
@@ -1,0 +1,17 @@
+package com.linkedin.norbert
+package network
+package netty
+/**
+ * @auther: rwang
+ * @date: 7/27/12
+ * @version: $Revision$
+ */
+
+import server.{Filter => SFilter, RequestContext => SRequestContext}
+import protos.NorbertProtos.NorbertMessage
+
+trait Filter extends SFilter {
+  def onMessage(message: NorbertMessage, context: SRequestContext) : Unit
+  def postMessage(message: NorbertMessage, context: SRequestContext) : Unit
+}
+

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -262,7 +262,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
                                                       (implicit is: InputSerializer[RequestMsg, ResponseMsg],
                                                        os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  = doIfConnected {
     val nodes = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
-      lb => lb.nodesForOneReplica(id))
+      lb => lb.nodesForOneReplica(id, capability))
 
     if (nodes.isEmpty) throw new NoNodesAvailableException("Unable to satisfy request, no node available for request")
 

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -150,7 +150,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * @param ids the <code>PartitionedId</code>s to which the message is addressed
    * @param message the message to send
    * @param requestBuilder A method which allows the user to generate a specialized request for a set of partitions
-   * before it is sent to the <code>Node</code>.
+   * before it is sent to the <code>Node</cod e>.
    * @param maxRetry maxium # of retry attempts
    *
    * @return a <code>ResponseIterator</code>. One response will be returned by each <code>Node</code>

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -53,15 +53,18 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   @volatile private var loadBalancer: Option[Either[InvalidClusterException, PartitionedLoadBalancer[PartitionedId]]] = None
 
   def sendRequest[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, callback: Either[Throwable, ResponseMsg] => Unit)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Unit =
+    sendRequest(id, request, callback, None)
+  
+  def sendRequest[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, callback: Either[Throwable, ResponseMsg] => Unit, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Unit = doIfConnected {
     if (id == null || request == null) throw new NullPointerException
 
     val node = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
-      lb => lb.nextNode(id).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id))))
+      lb => lb.nextNode(id, capability).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id))))
 
     doSendRequest(PartitionedRequest(request, node, Set(id), (node: Node, ids: Set[PartitionedId]) => request, is, os, callback))
   }
-
 
   /**
    * Sends a <code>Message</code> to the specified <code>PartitionedId</code>. The <code>PartitionedNetworkClient</code>
@@ -77,10 +80,15 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * to send the request to
    * @throws ClusterDisconnectedException thrown if the <code>PartitionedNetworkClient</code> is not connected to the cluster
    */
+
   def sendRequest[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Future[ResponseMsg] =
+    sendRequest(id, request, None)
+  
+  def sendRequest[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Future[ResponseMsg] = {
     val future = new FutureAdapter[ResponseMsg]
-    sendRequest(id, request, future)
+    sendRequest(id, request, future, capability)
     future
   }
 
@@ -100,8 +108,12 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * @throws ClusterDisconnectedException thrown if the <code>PartitionedNetworkClient</code> is not connected to the cluster
    */
   def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], request: RequestMsg)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] =
+    sendRequest(ids, request, None)
+  
+  def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], request: RequestMsg, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] = doIfConnected {
-    sendRequest(ids, (node: Node, ids: Set[PartitionedId]) => request)(is, os)
+    sendRequest(ids, (node: Node, ids: Set[PartitionedId]) => request, capability)(is, os)
   }
 
   /**
@@ -122,8 +134,12 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * @throws ClusterDisconnectedException thrown if the <code>PartitionedNetworkClient</code> is not connected to the cluster
    */
   def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] =
+    sendRequest(ids, requestBuilder, None)
+  
+  def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] = doIfConnected {
-    sendRequest(ids, requestBuilder, 0)
+    sendRequest(ids, requestBuilder, 0, capability)
   }
 
   /**
@@ -146,14 +162,18 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    */
   // TODO: investigate interplay between default parameter and implicits
   def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg, maxRetry: Int)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] =
+   sendRequest(ids, requestBuilder, maxRetry, None)
+
+  def sendRequest[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg, maxRetry: Int, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] = doIfConnected {
     if (ids == null || requestBuilder == null) throw new NullPointerException
-    val nodes = calculateNodesFromIds(ids)
+    val nodes = calculateNodesFromIds(ids, capability)
     val queue = new ResponseQueue[ResponseMsg]
     val resIter = new NorbertDynamicResponseIterator[ResponseMsg](nodes.size, queue)
     nodes.foreach { case (node, idsForNode) =>
       try {
-        doSendRequest(PartitionedRequest(requestBuilder(node, idsForNode), node, idsForNode, requestBuilder, is, os, if (maxRetry == 0) queue.+= else retryCallback[RequestMsg, ResponseMsg](queue.+=, maxRetry), 0, Some(resIter)))
+        doSendRequest(PartitionedRequest(requestBuilder(node, idsForNode), node, idsForNode, requestBuilder, is, os, if (maxRetry == 0) queue.+= else retryCallback[RequestMsg, ResponseMsg](queue.+=, maxRetry, capability), 0, Some(resIter)))
       } catch {
         case ex: Exception => queue += Left(ex)
       }
@@ -184,9 +204,17 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   def sendRequest[RequestMsg, ResponseMsg, Result](ids: Set[PartitionedId],
                                                    requestBuilder: (Node, Set[PartitionedId]) => RequestMsg,
                                                    responseAggregator: (ResponseIterator[ResponseMsg]) => Result)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Result =
+    sendRequest(ids, requestBuilder, responseAggregator, None)
+
+
+  def sendRequest[RequestMsg, ResponseMsg, Result](ids: Set[PartitionedId],
+                                                   requestBuilder: (Node, Set[PartitionedId]) => RequestMsg,
+                                                   responseAggregator: (ResponseIterator[ResponseMsg]) => Result,
+                                                   capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Result = doIfConnected {
     if (responseAggregator == null) throw new NullPointerException
-    responseAggregator(sendRequest[RequestMsg, ResponseMsg](ids, requestBuilder))
+    responseAggregator(sendRequest[RequestMsg, ResponseMsg](ids, requestBuilder, capability))
   }
 
   /**
@@ -203,8 +231,12 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * @throws ClusterDisconnectedException thrown if the <code>PartitionedNetworkClient</code> is not connected to the cluster
    */
   def sendRequestToOneReplica[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg)
+  (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] =
+    sendRequestToOneReplica(id, request, None)
+
+  def sendRequestToOneReplica[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, capability: Option[Long])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  = doIfConnected {
-    sendRequestToOneReplica(id, (node: Node, partitions: Set[Int]) => request)(is, os)
+    sendRequestToOneReplica(id, (node: Node, partitions: Set[Int]) => request, capability)(is, os)
   }
 
 
@@ -223,6 +255,11 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    */
   def sendRequestToOneReplica[RequestMsg, ResponseMsg](id: PartitionedId, requestBuilder: (Node, Set[Int]) => RequestMsg)
                                                       (implicit is: InputSerializer[RequestMsg, ResponseMsg],
+                                                       os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  =
+    sendRequestToOneReplica(id, requestBuilder, None)
+
+  def sendRequestToOneReplica[RequestMsg, ResponseMsg](id: PartitionedId, requestBuilder: (Node, Set[Int]) => RequestMsg, capability: Option[Long])
+                                                      (implicit is: InputSerializer[RequestMsg, ResponseMsg],
                                                        os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  = doIfConnected {
     val nodes = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
       lb => lb.nodesForOneReplica(id))
@@ -239,12 +276,16 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   }
 
   def sendRequestToReplicas[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, maxRetry : Int = 0)
+                                                    (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] =
+    sendRequestToReplicas(id, request, maxRetry, None)
+
+  def sendRequestToReplicas[RequestMsg, ResponseMsg](id: PartitionedId, request: RequestMsg, maxRetry : Int, capability: Option[Long])
                                                        (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg] = doIfConnected {
     if (id == null || request == null) throw new NullPointerException
     val nodes = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
                                                                                     lb =>
                                                                                     {
-                                                                                      val nodeSet = lb.nodesForPartitionedId(id)
+                                                                                      val nodeSet = lb.nodesForPartitionedId(id, capability)
                                                                                       if (nodeSet.isEmpty) throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id))
                                                                                       nodeSet
                                                                                     })
@@ -252,7 +293,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
     val resIter = new NorbertDynamicResponseIterator[ResponseMsg](nodes.size, queue)
     nodes.foreach { case (node) =>
       try {
-        doSendRequest(PartitionedRequest(request, node, Set(id), (node: Node, ids: Set[PartitionedId]) => request, is, os, if (maxRetry == 0) queue.+= else retryCallback[RequestMsg, ResponseMsg](queue.+=, maxRetry), 0, Some(resIter)))
+        doSendRequest(PartitionedRequest(request, node, Set(id), (node: Node, ids: Set[PartitionedId]) => request, is, os, if (maxRetry == 0) queue.+= else retryCallback[RequestMsg, ResponseMsg](queue.+=, maxRetry, capability), 0, Some(resIter)))
       } catch {
         case ex: Exception => queue += Left(ex)
       }
@@ -275,6 +316,11 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
    * @throws ClusterDisconnectedException thrown if the <code>PartitionedNetworkClient</code> is not connected to the cluster
    */
   def sendRequestToPartitions[RequestMsg, ResponseMsg](id: PartitionedId, partitions: Set[Int], requestBuilder: (Node, Set[Int]) => RequestMsg)
+                                                      (implicit is: InputSerializer[RequestMsg, ResponseMsg],
+                                                       os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  =
+    sendRequestToPartitions(id, partitions, requestBuilder, None)
+
+  def sendRequestToPartitions[RequestMsg, ResponseMsg](id: PartitionedId, partitions: Set[Int], requestBuilder: (Node, Set[Int]) => RequestMsg, capability: Option[Long])
                                                       (implicit is: InputSerializer[RequestMsg, ResponseMsg],
                                                        os: OutputSerializer[RequestMsg, ResponseMsg]): ResponseIterator[ResponseMsg]  = doIfConnected {
     val nodes = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
@@ -313,7 +359,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   /**
    * Internal callback wrapper to handle partial failures via RequestAccess
    */
-  private[partitioned] def retryCallback[RequestMsg, ResponseMsg](underlying: Either[Throwable, ResponseMsg] => Unit, maxRetry: Int)(res: Either[Throwable, ResponseMsg])
+  private[partitioned] def retryCallback[RequestMsg, ResponseMsg](underlying: Either[Throwable, ResponseMsg] => Unit, maxRetry: Int, capability: Option[Long])(res: Either[Throwable, ResponseMsg])
   (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]): Unit = {
     def propagate(t: Throwable) { log.info("Propagate exception(%s) to client".format(t)); underlying(Left(t)) }
     def handleFailure(t: Throwable) {
@@ -324,14 +370,14 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
           val requestBuilder = prequest.requestBuilder
           if (prequest.retryAttempt < maxRetry && prequest.responseIterator.isDefined && prequest.responseIterator.get.isInstanceOf[DynamicResponseIterator[ResponseMsg]]) {
             try {
-              val nodes = calculateNodesFromIds(prequest.partitionedIds, Set(prequest.node), 3)
+              val nodes = calculateNodesFromIds(prequest.partitionedIds, Set(prequest.node), 3, capability)
               if (nodes.keySet.size > 1) {
                 log.debug("Adjust responseIterator size by: %d".format(nodes.keySet.size - 1))
                 prequest.responseIterator.get.asInstanceOf[DynamicResponseIterator[ResponseMsg]].addAndGet(nodes.keySet.size - 1)
               }
               nodes.foreach {
                 case (node, idsForNode) =>
-                  val request1 = PartitionedRequest(requestBuilder(node, idsForNode), node, idsForNode, requestBuilder, is, os, retryCallback[RequestMsg, ResponseMsg](underlying, maxRetry), prequest.retryAttempt + 1, prequest.responseIterator)
+                  val request1 = PartitionedRequest(requestBuilder(node, idsForNode), node, idsForNode, requestBuilder, is, os, retryCallback[RequestMsg, ResponseMsg](underlying, maxRetry, capability), prequest.retryAttempt + 1, prequest.responseIterator)
                   log.debug("Resend request: %s".format(request1))
                   doSendRequest(request1)
               }
@@ -352,11 +398,11 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
       res.fold(t => handleFailure(t), result => underlying(Right(result)))
   }
 
-  private def calculateNodesFromIds(ids: Set[PartitionedId]) = {
+  private def calculateNodesFromIds(ids: Set[PartitionedId], capability: Option[Long]) = {
     val lb = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex, lb => lb)
 
     ids.foldLeft(Map[Node, Set[PartitionedId]]().withDefaultValue(Set())) { (map, id) =>
-      val node = lb.nextNode(id).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id)))
+      val node = lb.nextNode(id, capability).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id)))
       map.updated(node, map(node) + id)
     }
   }
@@ -364,7 +410,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   /**
    * For retry attempts. Failing nodes excluded
    */
-  private[partitioned] def calculateNodesFromIds(ids: Set[PartitionedId], excludedNodes: Set[Node], maxAttempts: Int) = {
+  private[partitioned] def calculateNodesFromIds(ids: Set[PartitionedId], excludedNodes: Set[Node], maxAttempts: Int,capability: Option[Long]) = {
     if (maxAttempts <= 0)
       throw new IllegalArgumentException
     val lb = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex, lb => lb)
@@ -374,7 +420,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
       var i = 0
       var node: Node = null
       while (i < maxAttempts && !foundIt) {
-        node = lb.nextNode(id).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id)))
+        node = lb.nextNode(id, capability).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id)))
         if (!excludedNodes.contains(node)) {
           foundIt = true
         }

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
@@ -20,7 +20,7 @@ package loadbalancer
 
 import cluster.{InvalidClusterException, Node}
 import common.Endpoint
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import annotation.tailrec
 import client.loadbalancer.LoadBalancerHelpers
 import logging.Logging
@@ -32,7 +32,7 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
   /**
    * A mapping from partition id to the <code>Node</code>s which can service that partition.
    */
-  protected val partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger)]
+  protected val partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger, Array[AtomicBoolean])]
 
   /**
    * Given the currently available <code>Node</code>s and the total number of partitions in the cluster, this method
@@ -45,7 +45,7 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
    * @throws InvalidClusterException thrown if every partition doesn't have at least one available <code>Node</code>
    * assigned to it
    */
-  protected def generatePartitionToNodeMap(nodes: Set[Endpoint], numPartitions: Int, serveRequestsIfPartitionMissing: Boolean): Map[Int, (IndexedSeq[Endpoint], AtomicInteger)] = {
+  protected def generatePartitionToNodeMap(nodes: Set[Endpoint], numPartitions: Int, serveRequestsIfPartitionMissing: Boolean): Map[Int, (IndexedSeq[Endpoint], AtomicInteger, Array[AtomicBoolean])] = {
     val partitionToNodeMap = (for (n <- nodes; p <- n.node.partitionIds) yield(p, n)).foldLeft(Map.empty[Int, IndexedSeq[Endpoint]]) {
       case (map, (partitionId, node)) => map + (partitionId -> (node +: map.get(partitionId).getOrElse(Vector.empty[Endpoint])))
     }
@@ -62,7 +62,12 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
         throw new InvalidClusterException("Partitions %s are unavailable, cannot serve requests.".format(missingPartitions))
     }
 
-    partitionToNodeMap.map { case (pId, endPoints) => pId -> (endPoints, new AtomicInteger(0)) }
+
+    partitionToNodeMap.map { case (pId, endPoints) =>
+      val states = new Array[AtomicBoolean](endPoints.size)
+      (0 to endPoints.size -1).foreach(states(_) = new AtomicBoolean(true))
+      pId -> (endPoints, new AtomicInteger(0), states) 
+    }
   }
 
   /**
@@ -77,15 +82,22 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
     partitionToNodeMap.get(partitionId) match {
       case None =>
         return None
-      case Some((endpoints, counter)) =>
+      case Some((endpoints, counter, states)) =>
+        import math._
+        val es = endpoints.size
+        counter.compareAndSet(java.lang.Integer.MAX_VALUE, 0)
         val idx = counter.getAndIncrement
         var i = idx
         do {
-          val endpoint = endpoints(i % endpoints.size)
+          val endpoint = endpoints(i % es)
           if(endpoint.canServeRequests && endpoint.node.isCapableOf(capability))
-            return Some(endpoint.node)
+            if (states(i % es).compareAndSet(true, false))
+              return Some(endpoint.node)
+            else if ((i - idx) >= es)
+              states(i % es).compareAndSet(false, true)
 
           i = i + 1
+          if (i < 0) i = 0
         } while(i != idx)
 
         return Some(endpoints(idx).node)

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultLoadBalancerHelper.scala
@@ -73,7 +73,7 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
    * @return <code>Some</code> with the <code>Node</code> which can service the partition id, <code>None</code>
    * if there are no available <code>Node</code>s for the partition requested
    */
-  protected def nodeForPartition(partitionId: Int): Option[Node] = {
+  protected def nodeForPartition(partitionId: Int, capability: Option[Long] = None): Option[Node] = {
     partitionToNodeMap.get(partitionId) match {
       case None =>
         return None
@@ -82,7 +82,7 @@ trait DefaultLoadBalancerHelper extends LoadBalancerHelpers with Logging {
         var i = idx
         do {
           val endpoint = endpoints(i % endpoints.size)
-          if(endpoint.canServeRequests)
+          if(endpoint.canServeRequests && endpoint.node.isCapableOf(capability))
             return Some(endpoint.node)
 
           i = i + 1

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultPartitionedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/DefaultPartitionedLoadBalancerFactory.scala
@@ -20,7 +20,7 @@ package loadbalancer
 
 import cluster.{Node, InvalidClusterException}
 import common.Endpoint
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 /**
  * This class is intended for applications where there is a mapping from partitions -> servers able to respond to those requests. Requests are round-robined
@@ -44,7 +44,7 @@ abstract class DefaultPartitionedLoadBalancerFactory[PartitionedId](serveRequest
     }
 
     def nodesForPartitionedId(id: PartitionedId, capability: Option[Long] = None) = {
-      partitionToNodeMap.getOrElse(partitionForId(id), (Vector.empty[Endpoint], new AtomicInteger(0)))._1.filter(_.node.isCapableOf(capability)).toSet.map
+      partitionToNodeMap.getOrElse(partitionForId(id), (Vector.empty[Endpoint], new AtomicInteger(0), new Array[AtomicBoolean](0)))._1.filter(_.node.isCapableOf(capability)).toSet.map
       { (endpoint: Endpoint) => endpoint.node }
     }
 
@@ -56,7 +56,7 @@ abstract class DefaultPartitionedLoadBalancerFactory[PartitionedId](serveRequest
       nodesForPartitions(id, partitionToNodeMap.filterKeys(partitions contains _), capability)
     }
 
-    def nodesForPartitions(id: PartitionedId, partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger)], capability: Option[Long]) = {
+    def nodesForPartitions(id: PartitionedId, partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger, Array[AtomicBoolean])], capability: Option[Long]) = {
       partitionToNodeMap.keys.foldLeft(Map.empty[Node, Set[Int]]) { (map, partition) =>
         val nodeOption = nodeForPartition(partition, capability)
         if(nodeOption.isDefined) {

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
@@ -34,7 +34,7 @@ class PartitionedConsistentHashedLoadBalancerFactory[PartitionedId](numPartition
                                                                     hashFn: PartitionedId => Int,
                                                                     endpointHashFn: String => Int,
                                                                     serveRequestsIfPartitionMissing: Boolean)
-  extends DefaultPartitionedLoadBalancerFactory[PartitionedId](serveRequestsIfPartitionMissing) {
+  extends DefaultPartitionedLoadBalancerFactory[PartitionedId](numPartitions, serveRequestsIfPartitionMissing) {
 
   def this(slicesPerEndpoint: Int, hashFn: PartitionedId => Int, endpointHashFn: String => Int, serveRequestsIfPartitionMissing: Boolean) = {
     this(-1, slicesPerEndpoint, hashFn, endpointHashFn, serveRequestsIfPartitionMissing)

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
@@ -5,7 +5,7 @@ import java.util.TreeMap
 import com.linkedin.norbert.cluster.{Node, InvalidClusterException}
 import com.linkedin.norbert.logging.Logging
 import com.linkedin.norbert.network.client.loadbalancer.LoadBalancerHelpers
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 /*
 * Copyright 2009-2010 LinkedIn, Inc
@@ -128,7 +128,7 @@ class PartitionedConsistentHashedLoadBalancer[PartitionedId](numPartitions: Int,
     }
   }  
   
-  private def nodesForPartitions0(partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger)], capability: Option[Long]) = {
+  private def nodesForPartitions0(partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger, Array[AtomicBoolean])], capability: Option[Long]) = {
     partitionToNodeMap.keys.foldLeft(Map.empty[Node, Set[Int]]) { (map, partition) =>
       val nodeOption = nodeForPartition(partition, capability)
       if(nodeOption isDefined) {

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerFactory.scala
@@ -85,28 +85,28 @@ class PartitionedConsistentHashedLoadBalancer[PartitionedId](numPartitions: Int,
   val partitionToNodeMap = generatePartitionToNodeMap(endpoints, numPartitions, serveRequestsIfPartitionMissing)
   val partitionIds = wheels.keySet.toSet
 
-  def nodesForOneReplica(id: PartitionedId) = {
-    nodesForPartitions(id, wheels)
+  def nodesForOneReplica(id: PartitionedId, capability: Option[Long] = None) = {
+    nodesForPartitions(id, wheels, capability)
   }
 
-  def nodesForPartitionedId(id: PartitionedId) = {
+  def nodesForPartitionedId(id: PartitionedId, capability: Option[Long] = None) = {
     val hash = hashFn(id)
     val partitionId = hash.abs % numPartitions
-    wheels.get(partitionId).flatMap { wheel => Option(wheel.foldLeft(Set.empty[Node]) { case (set, (p, e)) => set + e.node  }) }.get
+    wheels.get(partitionId).flatMap { wheel => Option(wheel.foldLeft(Set.empty[Node]) { case (set, (p, e)) => if (e.node.isCapableOf(capability)) set + e.node else set }) }.get
   }
 
-  def nodesForPartitions(id: PartitionedId, partitions: Set[Int]) = {
-    nodesForPartitions(id, wheels.filterKeys(partitions contains _))
+  def nodesForPartitions(id: PartitionedId, partitions: Set[Int], capability: Option[Long] = None) = {
+    nodesForPartitions(id, wheels.filterKeys(partitions contains _), capability)
   }
   
-  private def nodesForPartitions(id: PartitionedId, wheels: Map[Int, TreeMap[Int, Endpoint]]) = {
+  private def nodesForPartitions(id: PartitionedId, wheels: Map[Int, TreeMap[Int, Endpoint]], capability: Option[Long]) = {
     if (id == null) {
-      nodesForPartitions0(partitionToNodeMap filterKeys wheels.containsKey)
+      nodesForPartitions0(partitionToNodeMap filterKeys wheels.containsKey, capability)
     } else {
       val hash = hashFn(id)
 
       wheels.foldLeft(Map.empty[Node, Set[Int]]) { case (accumulator, (partitionId, wheel)) =>
-        val endpoint = PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => e.canServeRequests)
+        val endpoint = PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => e.canServeRequests && e.node.isCapableOf(capability) )
 
         if(endpoint.isDefined) {
           val node = endpoint.get.node
@@ -117,7 +117,7 @@ class PartitionedConsistentHashedLoadBalancer[PartitionedId](numPartitions: Int,
           log.warn("All nodes appear to be unresponsive for partition %s, selecting the original node."
             .format(partitionId))
 
-          val originalEndpoint = PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => true)
+          val originalEndpoint = PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => e.node.isCapableOf(capability))
           val node = originalEndpoint.get.node
           val partitions = accumulator.getOrElse(node, Set.empty[Int]) + partitionId
           accumulator + (node -> partitions)
@@ -128,9 +128,9 @@ class PartitionedConsistentHashedLoadBalancer[PartitionedId](numPartitions: Int,
     }
   }  
   
-  private def nodesForPartitions0(partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger)]) = {
+  private def nodesForPartitions0(partitionToNodeMap: Map[Int, (IndexedSeq[Endpoint], AtomicInteger)], capability: Option[Long]) = {
     partitionToNodeMap.keys.foldLeft(Map.empty[Node, Set[Int]]) { (map, partition) =>
-      val nodeOption = nodeForPartition(partition)
+      val nodeOption = nodeForPartition(partition, capability)
       if(nodeOption isDefined) {
         val n = nodeOption.get
         map + (n -> (map.getOrElse(n, Set.empty[Int]) + partition))
@@ -143,11 +143,11 @@ class PartitionedConsistentHashedLoadBalancer[PartitionedId](numPartitions: Int,
   }
   
 
-  def nextNode(id: PartitionedId): Option[Node] = {
+  def nextNode(id: PartitionedId, capability: Option[Long] = None): Option[Node] = {
     val hash = hashFn(id)
     val partitionId = hash.abs % numPartitions
     wheels.get(partitionId).flatMap { wheel =>
-      PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => e.canServeRequests)
+      PartitionUtil.searchWheel(wheel, hash, (e: Endpoint) => e.canServeRequests && e.node.isCapableOf(capability) )
     }.map(_.node)
   }
 

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedLoadBalancerFactory.scala
@@ -33,7 +33,7 @@ trait PartitionedLoadBalancer[PartitionedId] {
    *
    * @return the <code>Node</code> to route the next message to
    */
-  def nextNode(id: PartitionedId): Option[Node]
+  def nextNode(id: PartitionedId, capability: Option[Long] = None): Option[Node]
 
   /**
    * Returns a list of nodes representing one replica of the cluster, this is used by the PartitionedNetworkClient to handle
@@ -41,13 +41,13 @@ trait PartitionedLoadBalancer[PartitionedId] {
    *
    * @return the <code>Nodes</code> to broadcast the next message to a replica to
    */
-  def nodesForOneReplica(id: PartitionedId): Map[Node, Set[Int]]
+  def nodesForOneReplica(id: PartitionedId, capability: Option[Long] = None): Map[Node, Set[Int]]
 
   /**
    * Returns a list of nodes representing all replica for this particular partitionedId
    * @return the <code>Nodes</code> to multicast the message to
    */
-  def nodesForPartitionedId(id: PartitionedId): Set[Node]
+  def nodesForPartitionedId(id: PartitionedId, capability: Option[Long] = None): Set[Node]
 
   /**
    * Calculates a mapping of nodes to partitions for broadcasting a partitioned request. Optionally uses a partitioned
@@ -55,7 +55,7 @@ trait PartitionedLoadBalancer[PartitionedId] {
    *
    * @return the <code>Nodes</code> to broadcast the next message to a replica to
    */
-  def nodesForPartitions(id: PartitionedId, partitions: Set[Int]): Map[Node, Set[Int]]
+  def nodesForPartitions(id: PartitionedId, partitions: Set[Int], capability: Option[Long] = None): Map[Node, Set[Int]]
 }
 
 /**

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/SimpleConsistentHashedLoadBalancerFactory.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/SimpleConsistentHashedLoadBalancerFactory.scala
@@ -52,13 +52,13 @@ class SimpleConsistentHashedLoadBalancerFactory[PartitionedId](numReplicas: Int,
 
 class SimpleConsistentHashedLoadBalancer[PartitionedId](wheel: TreeMap[Int, Endpoint], hashFn: PartitionedId => Int) extends PartitionedLoadBalancer[PartitionedId] {
 
-  def nodesForOneReplica(id: PartitionedId) = throw new UnsupportedOperationException
+  def nodesForOneReplica(id: PartitionedId, capability: Option[Long] = None) = throw new UnsupportedOperationException
 
-  def nodesForPartitionedId(id: PartitionedId) = throw new UnsupportedOperationException
+  def nodesForPartitionedId(id: PartitionedId, capability: Option[Long] = None) = throw new UnsupportedOperationException
 
-  def nodesForPartitions(id: PartitionedId, partitions: Set[Int]) = throw new UnsupportedOperationException
+  def nodesForPartitions(id: PartitionedId, partitions: Set[Int], capability: Option[Long] = None) = throw new UnsupportedOperationException
 
-  def nextNode(id: PartitionedId): Option[Node] = {
-    PartitionUtil.searchWheel(wheel, hashFn(id), (e: Endpoint) => e.canServeRequests).map(_.node)
+  def nextNode(id: PartitionedId, capability: Option[Long]): Option[Node] = {
+    PartitionUtil.searchWheel(wheel, hashFn(id), (e: Endpoint) => e.canServeRequests && e.node.isCapableOf(capability)).map(_.node)
   }
 }

--- a/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/server/NetworkServer.scala
@@ -49,6 +49,8 @@ trait NetworkServer extends Logging {
     messageHandlerRegistry.registerHandler(handler)
   }
 
+  def addFilters(filters: List[Filter]) : Unit = messageExecutor.addFilters(filters)
+
   /**
    * Binds the network server instance to the wildcard address and the port of the <code>Node</code> identified
    * by the provided nodeId and automatically marks the <code>Node</code> available in the cluster.  A

--- a/network/src/main/scala/com/linkedin/norbert/network/server/RequestContext.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/server/RequestContext.scala
@@ -1,0 +1,14 @@
+package com.linkedin.norbert.network.server
+
+import scala.collection.mutable.Map
+
+/**
+ * @auther: rwang
+ * @date: 7/26/12
+ * @version: $Revision$
+ */
+trait RequestContext
+{
+  val attributes : Map[String,  Any] = Map.empty[String, Any]
+}
+

--- a/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
@@ -75,6 +75,20 @@ class NetworkClientSpec extends BaseNetworkClientSpecification {
 //      clusterIoClient.sendMessage(node, message, null) was called
     }
 
+    "send the provided message to the node specified by the load balancer for sendMessage with the requested capability " in {
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
+      networkClient.lb.nextNode(Some(0x1)) returns Some(nodes(1))
+
+      networkClient.start
+      networkClient.sendRequest(request, Some(1L)) must notBeNull
+
+      there was one(networkClient.lb).nextNode(Some(0x1))
+      there was no(networkClient.lb).nextNode(None)
+    }
+
     "retryCallback should propagate server exception to underlying when" in {
 
       val MAX_RETRY = 3

--- a/network/src/test/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactorySpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/client/loadbalancer/RoundRobinLoadBalancerFactorySpec.scala
@@ -75,5 +75,29 @@ class RoundRobinLoadBalancerFactorySpec extends Specification {
         node must be_==(Node(nodeId, "localhost:3131" + nodeId, true))
       }
     }
+
+    "Not route to node cannot fulfill capability" in {
+      val nodes = for (i <- 0 until 4) yield Node(i, "localhost:3131" + i,  true, Set.empty[Int], Some(i))
+
+      val endpoints = nodes.map(n => new Endpoint {
+        def node = n
+        def canServeRequests = true
+      }).toSet
+
+      val loadBalancerFactory = new RoundRobinLoadBalancerFactory
+      val lb = loadBalancerFactory.newLoadBalancer(endpoints)
+
+      for(i <- 0 until 8) {
+        val node = lb.nextNode.get
+        val nodeId = i % 4
+        node must be_==(Node(nodeId, "localhost:3131" + nodeId, true))
+      }
+
+      for(i <- 0 until 8) {
+        val node = lb.nextNode(Some(1)).get
+        val nodeId = ((i % 2) << 1) | 1
+        node must be_==(Node(nodeId, "localhost:3131" + nodeId, true))
+      }
+    }
   }
 }

--- a/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
@@ -21,9 +21,10 @@ import org.specs.Specification
 import org.specs.mock.Mockito
 import client.NetworkClient
 import client.loadbalancer.{LoadBalancerFactory, LoadBalancer, LoadBalancerFactoryComponent}
-import server.{MessageExecutorComponent, MessageExecutor}
+import server.{MessageExecutorComponent, MessageExecutor, Filter, RequestContext}
 import cluster.{Node, ClusterClientComponent, ClusterClient}
 import com.google.protobuf.Message
+import scala.collection.mutable.MutableList
 
 class LocalMessageExecutionSpec extends Specification with Mockito with SampleMessage {
   val clusterClient = mock[ClusterClient]
@@ -31,10 +32,10 @@ class LocalMessageExecutionSpec extends Specification with Mockito with SampleMe
   val messageExecutor = new MessageExecutor {
     var called = false
     var request: Any = _
-
+    val filters = new MutableList[Filter]
     def shutdown = {}
 
-    def executeMessage[RequestMsg, ResponseMsg](request: RequestMsg, responseHandler: (Either[Exception, ResponseMsg]) => Unit)(implicit is: InputSerializer[RequestMsg, ResponseMsg]) = {
+    def executeMessage[RequestMsg, ResponseMsg](request: RequestMsg, responseHandler: (Either[Exception, ResponseMsg]) => Unit, context: Option[RequestContext])(implicit is: InputSerializer[RequestMsg, ResponseMsg]) = {
       called = true
       this.request = request
 

--- a/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
@@ -71,7 +71,7 @@ class LocalMessageExecutionSpec extends Specification with Mockito with SampleMe
 
   "LocalMessageExecution" should {
     "call the MessageExecutor if myNode is equal to the node the request is to be sent to" in {
-      networkClient.lb.nextNode returns Some(networkClient.myNode)
+      networkClient.lb.nextNode(None) returns Some(networkClient.myNode)
 
       networkClient.start
 
@@ -82,7 +82,7 @@ class LocalMessageExecutionSpec extends Specification with Mockito with SampleMe
     }
 
     "not call the MessageExecutor if myNode is not equal to the node the request is to be sent to" in {
-      networkClient.lb.nextNode returns Some(Node(2, "", true))
+      networkClient.lb.nextNode(None) returns Some(Node(2, "", true))
 
       networkClient.start
       networkClient.sendRequest(request) must notBeNull

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
@@ -73,13 +73,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns Some(nodes(1))
+        networkClient.lb.nextNode(1, None) returns Some(nodes(1))
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(1, request) must notBeNull
 
-        there was one(networkClient.lb).nextNode(1)
+        there was one(networkClient.lb).nextNode(1, None)
 //      clusterIoClient.sendRequest(node, message, null) was called
       }
 
@@ -101,13 +101,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns None
+        networkClient.lb.nextNode(1, None) returns None
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(1, request) must throwA[NoNodesAvailableException]
 
-        there was one(networkClient.lb).nextNode(1)
+        there was one(networkClient.lb).nextNode(1, None)
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
     }
@@ -118,9 +118,9 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns Some(nodes(1))
-        networkClient.lb.nextNode(2) returns Some(nodes(2))
-        networkClient.lb.nextNode(3) returns Some(nodes(1))
+        networkClient.lb.nextNode(1, None) returns Some(nodes(1))
+        networkClient.lb.nextNode(2, None) returns Some(nodes(2))
+        networkClient.lb.nextNode(3, None) returns Some(nodes(1))
 
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
@@ -128,9 +128,9 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         networkClient.sendRequest(Set(1, 2, 3), request) must notBeNull
 
         got {
-          one(networkClient.lb).nextNode(1)
-          one(networkClient.lb).nextNode(2)
-          one(networkClient.lb).nextNode(3)
+          one(networkClient.lb).nextNode(1, None)
+          one(networkClient.lb).nextNode(2, None)
+          one(networkClient.lb).nextNode(3, None)
         }
 //      clusterIoClient.sendRequest(node, message, null) was called
       }
@@ -153,13 +153,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns None
+        networkClient.lb.nextNode(1, None) returns None
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), request) must throwA[NoNodesAvailableException]
 
-        there was one(networkClient.lb).nextNode(1)
+        there was one(networkClient.lb).nextNode(1, None)
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
     }
@@ -170,13 +170,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2, 3).foreach(networkClient.lb.nextNode(_) returns Some(Node(1, "localhost:31313", true)))
+        List(1, 2, 3).foreach(networkClient.lb.nextNode(_, None) returns Some(Node(1, "localhost:31313", true)))
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _)
 
-        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_))
+        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_, None))
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
 
@@ -194,8 +194,8 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
-        List(3, 4).foreach(networkClient.lb.nextNode(_) returns Some(nodes(1)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
+        List(3, 4).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(1)))
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3, 4), mc _)
@@ -215,7 +215,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
 
         networkClient.start
         val ri = networkClient.sendRequest(Set(1, 2), mc _)
@@ -241,13 +241,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns None
+        networkClient.lb.nextNode(1, None) returns None
 //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _) must throwA[NoNodesAvailableException]
 
-        there was one(networkClient.lb).nextNode(1)
+        there was one(networkClient.lb).nextNode(1, None)
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
     }
@@ -261,12 +261,12 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2, 3).foreach(networkClient.lb.nextNode(_) returns Some(Node(1, "localhost:31313", true)))
+        List(1, 2, 3).foreach(networkClient.lb.nextNode(_, None) returns Some(Node(1, "localhost:31313", true)))
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _, MAX_RETRY)
 
-        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_))
+        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_, None))
       }
 
       "call the message customizer" in {
@@ -283,8 +283,8 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
-        List(3, 4).foreach(networkClient.lb.nextNode(_) returns Some(nodes(1)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
+        List(3, 4).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(1)))
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3, 4), mc _, MAX_RETRY)
@@ -304,7 +304,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
 
         networkClient.start
         val ri = networkClient.sendRequest(Set(1, 2), mc _, MAX_RETRY)
@@ -327,12 +327,12 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns None
+        networkClient.lb.nextNode(1, None) returns None
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _, MAX_RETRY) must throwA[NoNodesAvailableException]
 
-        there was one(networkClient.lb).nextNode(1)
+        there was one(networkClient.lb).nextNode(1, None)
       }
     }
 
@@ -343,12 +343,12 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1,2,3).foreach(networkClient.lb.nodesForPartitionedId(_) returns nodeSet)
+        List(1,2,3).foreach(networkClient.lb.nodesForPartitionedId(_, None) returns nodeSet)
 
         networkClient.start
         networkClient.sendRequestToReplicas(2, request)
         got {
-          one(networkClient.lb).nodesForPartitionedId(2)
+          one(networkClient.lb).nodesForPartitionedId(2, None)
         }
       }
 
@@ -367,11 +367,11 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nodesForPartitionedId(1) returns (Set.empty[Node])
+        networkClient.lb.nodesForPartitionedId(1, None) returns (Set.empty[Node])
 
         networkClient.start
         networkClient.sendRequestToReplicas(1, request) must throwA[NoNodesAvailableException]
-        there was one(networkClient.lb).nodesForPartitionedId(1)
+        there was one(networkClient.lb).nodesForPartitionedId(1, None)
       }
       
     }
@@ -383,7 +383,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       val callback = (e: Either[Throwable, Ping]) => either = e
 
       "exception does not provide RequestAccess" in {
-        networkClient.retryCallback[Ping, Ping](callback, 0)(Left(new Exception)) // fallback to underlying
+        networkClient.retryCallback[Ping, Ping](callback, 0, None)(Left(new Exception)) // fallback to underlying
         either must notBeNull
         either.isLeft must beTrue
       }
@@ -393,7 +393,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         val ra: Exception with RequestAccess[Request[Ping, Ping]] = new Exception with RequestAccess[Request[Ping, Ping]] {
           def request = req
         }
-        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY)(Left(ra))
+        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY, None)(Left(ra))
         either must notBeNull
         either.isLeft must beTrue
         either.left.get mustEq ra
@@ -404,10 +404,10 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns None
+        networkClient.lb.nextNode(1, None) returns None
         networkClient.start
 
-        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY)(Left(new RemoteException("FooClass", "ServerError")))
+        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY, None)(Left(new RemoteException("FooClass", "ServerError")))
         either must notBeNull
         either.isLeft must beTrue
         either.left.get must haveClass[RemoteException]
@@ -418,7 +418,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        networkClient.lb.nextNode(1) returns Some(nodes(1)) // node(1) -> node(1) -> node(1)
+        networkClient.lb.nextNode(1, None) returns Some(nodes(1)) // node(1) -> node(1) -> node(1)
 
         networkClient.start
 
@@ -427,7 +427,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
           def request = req
         }
 
-        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY)(Left(ra))
+        networkClient.retryCallback[Ping, Ping](callback, MAX_RETRY, None)(Left(ra))
         either must notBeNull
         either.isLeft must beTrue
         either.left.get mustEq ra
@@ -437,13 +437,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         val nc2 = new PartitionedNetworkClient[Int] with ClusterClientComponent with ClusterIoClientComponent with PartitionedLoadBalancerFactoryComponent[Int] {
           val lb = new PartitionedLoadBalancer[Int] {
             var iter = PartitionedNetworkClientSpec.this.nodes.iterator
-            def nextNode(id: Int) = {
+            def nextNode(id: Int, c: Option[Long] = None) = {
               if (!iter.hasNext ) iter = PartitionedNetworkClientSpec.this.nodes.iterator
               Some(iter.next)
             }
-            def nodesForOneReplica(id: Int) = null
-            def nodesForPartitionedId(id:Int) = null
-            def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+            def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+            def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+            def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
           }
           val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
           val clusterIoClient = new ClusterIoClient {
@@ -478,13 +478,13 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         val lb = new PartitionedLoadBalancer[Int] {
           val nodeIS = PartitionedNetworkClientSpec.this.nodes.toIndexedSeq
           var idx = 0
-          def nextNode(id: Int) = {
+          def nextNode(id: Int, c: Option[Long] = None) = {
             idx = (idx + 1) % nodeIS.size
             Some(nodeIS(idx))
           }
-          def nodesForOneReplica(id: Int) = null
-          def nodesForPartitionedId(id:Int) = null
-          def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+          def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+          def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+          def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
         }
         val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
         val clusterIoClient = new ClusterIoClient {
@@ -521,7 +521,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         val lb = new PartitionedLoadBalancer[Int] {
           val nodeIS = PartitionedNetworkClientSpec.this.nodes.toIndexedSeq
           var count = 0
-          def nextNode(id: Int) = {
+          def nextNode(id: Int, c: Option[Long] = None) = {
             var ret: Node = null
             if (count < 2)
               ret = nodes(0)
@@ -530,9 +530,9 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
             count += 1
             Some(ret)
           }
-          def nodesForOneReplica(id: Int) = null
-          def nodesForPartitionedId(id:Int) = null
-          def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+          def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+          def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+          def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
         }
         val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
         val clusterIoClient = new ClusterIoClient {
@@ -570,10 +570,10 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       val nc2 = new PartitionedNetworkClient[Int] with ClusterClientComponent with ClusterIoClientComponent with PartitionedLoadBalancerFactoryComponent[Int] {
         val lb = new PartitionedLoadBalancer[Int] {
           val iter = PartitionedNetworkClientSpec.this.nodes.iterator
-          def nextNode(id: Int) = Some(iter.next)
-          def nodesForOneReplica(id: Int) = null
-          def nodesForPartitionedId(id:Int) = null
-          def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+          def nextNode(id: Int, c: Option[Long] = None) = Some(iter.next)
+          def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+          def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+          def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
         }
         val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
         val clusterIoClient = new ClusterIoClient {
@@ -596,7 +596,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
 
       val failingNode = nodes(0)
       val failingNodes = Set(failingNode)
-      var nodes2Ids = nc2.calculateNodesFromIds(Set(1), failingNodes, 3)
+      var nodes2Ids = nc2.calculateNodesFromIds(Set(1), failingNodes, 3, None)
       nodes2Ids must notBeNull
       nodes2Ids.keys must notHave(failingNodes)
     }
@@ -605,10 +605,10 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       val nc2 = new PartitionedNetworkClient[Int] with ClusterClientComponent with ClusterIoClientComponent with PartitionedLoadBalancerFactoryComponent[Int] {
         val lb = new PartitionedLoadBalancer[Int] {
           val iter = PartitionedNetworkClientSpec.this.nodes.iterator
-          def nextNode(id: Int) = Some(iter.next)
-          def nodesForOneReplica(id: Int) = null
-          def nodesForPartitionedId(id:Int) = null
-          def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+          def nextNode(id: Int, c: Option[Long] = None) = Some(iter.next)
+          def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+          def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+          def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
         }
         val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
         val clusterIoClient = new ClusterIoClient {
@@ -630,7 +630,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       nc2.start
 
       val failingNodes = Set(nodes(0), nodes(1))
-      var nodes2Ids = nc2.calculateNodesFromIds(Set(1), failingNodes, 3)
+      var nodes2Ids = nc2.calculateNodesFromIds(Set(1), failingNodes, 3, None)
       nodes2Ids must notBeNull
       nodes2Ids.keys must notHave(failingNodes)
     }
@@ -639,10 +639,10 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       val nc2 = new PartitionedNetworkClient[Int] with ClusterClientComponent with ClusterIoClientComponent with PartitionedLoadBalancerFactoryComponent[Int] {
         val lb = new PartitionedLoadBalancer[Int] {
           val iter = PartitionedNetworkClientSpec.this.nodes.iterator
-          def nextNode(id: Int) = if (iter.hasNext) Some(iter.next) else None
-          def nodesForOneReplica(id: Int) = null
-          def nodesForPartitionedId(id:Int) = null
-          def nodesForPartitions(id: Int, partitions: Set[Int]) = null
+          def nextNode(id: Int, c: Option[Long] = None) = if (iter.hasNext) Some(iter.next) else None
+          def nodesForOneReplica(id: Int, c: Option[Long] = None) = null
+          def nodesForPartitionedId(id:Int, c: Option[Long] = None) = null
+          def nodesForPartitions(id: Int, partitions: Set[Int], c: Option[Long] = None) = null
         }
         val loadBalancerFactory = mock[PartitionedLoadBalancerFactory[Int]]
         val clusterIoClient = new ClusterIoClient {
@@ -664,7 +664,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       nc2.start
 
       val failingNodes = Set(nodes(0), nodes(1), nodes(2))
-      nc2.calculateNodesFromIds(Set(1), failingNodes, 3) must throwA[NoNodesAvailableException]
+      nc2.calculateNodesFromIds(Set(1), failingNodes, 3, None) must throwA[NoNodesAvailableException]
     }
 
     "when sendRequest is called with a response aggregator" in {
@@ -679,7 +679,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2), (node: Node, ids: Set[Int]) => request, ag _) must be_==(123454321)
@@ -696,7 +696,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
-        List(1, 2).foreach(networkClient.lb.nextNode(_) returns Some(nodes(0)))
+        List(1, 2).foreach(networkClient.lb.nextNode(_, None) returns Some(nodes(0)))
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2), (node: Node, ids: Set[Int]) => request, ag _) must throwA[Exception]

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
@@ -26,7 +26,7 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
   case class EId(id: Int)
   implicit def eId2ByteArray(eId: EId): Array[Byte] = BigInt(eId.id).toByteArray
 
-  class EIdDefaultLoadBalancerFactory(numPartitions: Int, serveRequestsIfPartitionMissing: Boolean) extends DefaultPartitionedLoadBalancerFactory[EId](serveRequestsIfPartitionMissing) {
+  class EIdDefaultLoadBalancerFactory(numPartitions: Int, serveRequestsIfPartitionMissing: Boolean) extends DefaultPartitionedLoadBalancerFactory[EId](numPartitions, serveRequestsIfPartitionMissing) {
     protected def calculateHash(id: EId) = HashFunctions.fnv(id)
 
     def getNumPartitions(endpoints: Set[Endpoint]) = numPartitions

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/ConsistentHashPartitionedLoadBalancerFactorySpec.scala
@@ -54,6 +54,26 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
         Node(4, "localhost:31313", true, Set(0, 4))) must contain(_))
     }
 
+    "nextNode with capability return the correct node for 1210" in {
+      val nodes = Set(
+        Node(0, "localhost:31313", true, Set(0, 1)),
+        Node(1, "localhost:31313", true, Set(1, 2)),
+        Node(2, "localhost:31313", true, Set(2, 3)),
+        Node(3, "localhost:31313", true, Set(3, 4)),
+        Node(4, "localhost:31313", true, Set(0, 4), Some(0x2)),
+        Node(5, "localhost:31313", true, Set(3, 0), Some(0x3)))
+
+      val lb = loadBalancerFactory.newLoadBalancer(toEndpoints(nodes))
+      lb.nextNode(EId(1210)) must beSome[Node].which(List(Node(0, "localhost:31313", true, Set(0, 1)),
+                                                          Node(4, "localhost:31313", true, Set(0, 4), Some(0x2)),
+                                                          Node(5, "localhost:31313", true, Set(3, 0), Some(0x3))) must contain(_))
+      lb.nextNode(EId(1210), Some(0x1)) must be_==(Some(Node(5, "localhost:31313", true, Set(3,0), Some(0x3))))
+      lb.nextNode(EId(1210), Some(0x2)) must beSome[Node].which(List(Node(4, "localhost:31313", true, Set(0, 4), Some(0x2)),
+                                                                     Node(5, "localhost:31313", true, Set(3, 0), Some(0x3))) must contain(_))
+      //HIGH TODO: overflow @DefaultLoadBalancerHelper.nodeForPartition
+      //lb.nextNode(EId(1210), Some(0x4)) must be_==(None)
+    }
+
 
     "throw InvalidClusterException if all partitions are unavailable" in {
       val nodes = Set(
@@ -99,5 +119,39 @@ class ConsistentHashPartitionedLoadBalancerFactorySpec extends Specification {
                                                                           Node(3, "localhost:45123", true, Set(3,4,0)),
                                                                           Node(4, "localhost:51234", true, Set(4,0,1))))
      }
+
+    "nodesForPartitionedId returns only nodes satisfying capabiity requirements" in {
+      val nodes = Set (
+        Node(0, "localhost:12345", true, Set(0,1,2), Some(0x1)),
+        Node(1, "localhost:23451", true, Set(1,2,3)),
+        Node(2, "localhost:34512", true, Set(2,3,4)),
+        Node(3, "localhost:45123", true, Set(3,4,0)),
+        Node(4, "localhost:51234", true, Set(4,0,1), Some(0x2))
+      )
+      val lb = loadBalancerFactory.newLoadBalancer(toEndpoints(nodes))
+      lb.nodesForPartitionedId(EId(1210)) must haveTheSameElementsAs (Set(Node(0, "localhost:12345", true, Set(0,1,2)),
+                                                                          Node(3, "localhost:45123", true, Set(3,4,0)),
+                                                                          Node(4, "localhost:51234", true, Set(4,0,1))))
+
+      lb.nodesForPartitionedId(EId(1210), Some(0x1)) must haveTheSameElementsAs (Set(Node(0, "localhost:12345", true, Set(0,1,2), Some(0x1))))
+      lb.nodesForPartitionedId(EId(1210), Some(0x2)) must haveTheSameElementsAs (Set(Node(4, "localhost:51234", true, Set(4,0,1), Some(0x2))))
+      lb.nodesForPartitionedId(EId(1210), Some(0x3)) must haveTheSameElementsAs (Set())
+    }
+    
+    "nodesForOneReplica returns only nodes satisfying capability requirements" in {
+      val nodes = Set (
+        Node(0, "localhost:12345", true, Set(0,1,2), Some(0x1)),
+        Node(1, "localhost:23451", true, Set(1,2,3)),
+        Node(2, "localhost:34512", true, Set(2,3,4), Some(0x2)),
+        Node(3, "localhost:45123", true, Set(3,4,0), Some(0x3)),
+        Node(4, "localhost:51234", true, Set(4,0,1), Some(0x6))
+      )
+      val lb = loadBalancerFactory.newLoadBalancer(toEndpoints(nodes))
+      lb.nodesForOneReplica(EId(1210), Some(0x1)) must haveTheSameElementsAs (Map(Node(0, "localhost:12345", true, Set(0,1,2), Some(0x1)) -> Set(0,1,2),
+                                                                          Node(3, "localhost:45123", true, Set(3,4,0), Some(0x3)) -> Set(3,4)))
+      lb.nodesForOneReplica(EId(1210), Some(0x2)) must haveTheSameElementsAs (Map(Node(2, "localhost:34512", true, Set(2,3,4), Some(0x2)) -> Set(2,3),
+                                                                          Node(4, "localhost:51234", true, Set(4,0,1), Some(0x6)) -> Set(0,1),
+                                                                          Node(3, "localhost:45123", true, Set(3,4,0), Some(0x3)) -> Set(4)))
+    }
   }
 }

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/loadbalancer/PartitionedConsistentHashedLoadBalancerSpec.scala
@@ -55,11 +55,11 @@ class PartitionedConsistentHashedLoadBalancerSpec extends Specification {
 //  }
   
   val sampleNodes = Set(
-    Node(0, "localhost:31313", true, Set(0, 1)),
+    Node(0, "localhost:31313", true, Set(0, 1), Some(0x1)),
     Node(1, "localhost:31313", true, Set(1, 2)),
     Node(2, "localhost:31313", true, Set(2, 3)),
     Node(3, "localhost:31313", true, Set(3, 4)),
-    Node(4, "localhost:31313", true, Set(0, 4)))
+    Node(4, "localhost:31313", true, Set(0, 4), Some(0x2)))
   
 
   "ConsistentHashPartitionedLoadBalancer" should {
@@ -68,8 +68,11 @@ class PartitionedConsistentHashedLoadBalancerSpec extends Specification {
       val lb = loadBalancerFactory.newLoadBalancer(toEndpoints(nodes))
       lb.nextNode(1210) must beSome[Node].which(List(Node(0, "localhost:31313", true, Set(0, 1)),
         Node(4, "localhost:31313", true, Set(0, 4))) must contain(_))
+      
+      lb.nextNode(1210, Some(0x1)) must be_==(Some(Node(0, "localhost:31313", true, Set(0, 1))))
+      lb.nextNode(1210, Some(0x2)) must be_==(Some(Node(4, "localhost:31313", true, Set(0, 4))))
+      lb.nextNode(1210, Some(0x5)) must be_==(None)
     }
-
 
     "throw InvalidClusterException if all partitions are unavailable" in {
       val nodes = Set(
@@ -104,6 +107,7 @@ class PartitionedConsistentHashedLoadBalancerSpec extends Specification {
       val nodes = sampleNodes
       val lb = loadBalancerFactory.newLoadBalancer(toEndpoints(nodes))
       lb.nodesForPartitionedId(1210) must haveTheSameElementsAs (Set(Node(0, "localhost:31313", true, Set(0, 1)), Node(4, "localhost:31313", true, Set(0, 4))))
+      lb.nodesForPartitionedId(1210, Some(0x1)) must haveTheSameElementsAs (Set(Node(0, "localhost:31313", true, Set(0, 1))))
     }
 
     "handle endpoints going down" in {

--- a/network/src/test/scala/com/linkedin/norbert/network/server/NetworkServerSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/server/NetworkServerSpec.scala
@@ -21,6 +21,7 @@ import org.specs.Specification
 import org.specs.mock.Mockito
 import cluster._
 import network.common.SampleMessage
+import scala.collection.mutable.MutableList
 
 class NetworkServerSpec extends Specification with Mockito with SampleMessage {
   val networkServer = new NetworkServer with ClusterClientComponent with ClusterIoServerComponent with MessageHandlerRegistryComponent
@@ -28,7 +29,7 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
     val clusterIoServer = mock[ClusterIoServer]
     val clusterClient = mock[ClusterClient]
     val messageHandlerRegistry = mock[MessageHandlerRegistry]
-    val messageExecutor = null
+    val messageExecutor = mock[MessageExecutor]
   }
 
   val node = Node(1, "", false)
@@ -56,6 +57,14 @@ class NetworkServerSpec extends Specification with Mockito with SampleMessage {
       doNothing.when(networkServer.messageHandlerRegistry).registerHandler((ping: Ping) => new Ping)
 
       networkServer.registerHandler((ping : Ping) => new Ping)
+    }
+
+    "add filters with the MessageExcutor" in {
+      val filters = mock[List[Filter]]
+      doNothing.when(networkServer.messageExecutor).addFilters(filters)
+
+      networkServer.addFilters(filters)
+      there was one(networkServer.messageExecutor).addFilters(filters)
     }
 
     "when bind is called" in {

--- a/sbt
+++ b/sbt
@@ -1,1 +1,1 @@
-java $SBT_OPS -Xms1g -Xmx1g -server -XX:PermSize=128m -XX:MaxPermSize=128m -XX:+UseParallelOldGC -jar `dirname $0`/build/sbt-launch.jar "$@"
+java $SBT_OPS -Xms1g -Xmx1g -server -XX:PermSize=128m -XX:MaxPermSize=256m -XX:+UseParallelOldGC -jar `dirname $0`/build/sbt-launch.jar "$@"


### PR DESCRIPTION
Overloaded nextNode on NetworkClient, but used Option[Long] with default None parameter for PartitionedNetworkClient APIs. The reason being to avoid breaking existing client that call NetworkClient.nextNode without ().

Updated existing load balancer implementation accordingly. 

Added unit testings.
