### PR TITLE
Clean up the entire channel pool every K requests

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/norbertutils/package.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/norbertutils/package.scala
@@ -45,9 +45,11 @@ package object norbertutils {
   def atomicCreateIfAbsent[K, V](map: ConcurrentMap[K, V], key: K)(fn: K => V): V = {
     val oldValue = map.get(key)
     if(oldValue == null) {
-      val newValue = fn(key)
-      map.putIfAbsent(key, newValue)
-      map.get(key)
+      map.synchronized {
+        val newValue = fn(key)
+        map.putIfAbsent(key, newValue)
+        map.get(key)
+      }
     } else {
       oldValue
     }

--- a/network/src/main/scala/com/linkedin/norbert/network/NetworkDefaults.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/NetworkDefaults.scala
@@ -47,6 +47,11 @@ object NetworkDefaults {
   val STALE_REQUEST_TIMEOUT_MINS = 1
 
   /**
+   * How long to keep a channel alive before we'll toss it away
+   */
+  val CLOSE_CHANNEL_TIMEOUT_MILLIS = 30000L
+
+  /**
    * The amount of time before a request is considered "timed out" by the processing queue. If for some reason (perhaps a GC), when the request
    * is pulled from the queue and has been sitting in the queue for longer than this time, a HeavyLoadException is thrown to the client, signalling a throttle.
    */

--- a/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/client/NetworkClient.scala
@@ -34,8 +34,10 @@ class NetworkClientConfig {
   var connectTimeoutMillis = NetworkDefaults.CONNECT_TIMEOUT_MILLIS
   var writeTimeoutMillis = NetworkDefaults.WRITE_TIMEOUT_MILLIS
   var maxConnectionsPerNode = NetworkDefaults.MAX_CONNECTIONS_PER_NODE
+
   var staleRequestTimeoutMins = NetworkDefaults.STALE_REQUEST_TIMEOUT_MINS
   var staleRequestCleanupFrequenceMins = NetworkDefaults.STALE_REQUEST_CLEANUP_FREQUENCY_MINS
+  var closeChannelTimeMillis = NetworkDefaults.CLOSE_CHANNEL_TIMEOUT_MILLIS
 
   var requestStatisticsWindow = NetworkDefaults.REQUEST_STATISTICS_WINDOW
 

--- a/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/common/NorbertFuture.scala
@@ -99,21 +99,25 @@ case class TimeoutIterator[ResponseMsg](inner: ResponseIterator[ResponseMsg], ti
 
   def next: ResponseMsg = {
     val before = System.currentTimeMillis
-    val res = inner.next(timeLeft.get, TimeUnit.MILLISECONDS)
-    val time = (System.currentTimeMillis - before).asInstanceOf[Int]
 
-    timeLeft.addAndGet(-time)
-    res
+    try {
+      return inner.next(timeLeft.get, TimeUnit.MILLISECONDS)
+    } finally {
+      val time = (System.currentTimeMillis - before).asInstanceOf[Int]
+      timeLeft.addAndGet(-time)
+    }
   }
 
   def next(t: Long, unit: TimeUnit): ResponseMsg = {
     val before = System.currentTimeMillis
     val methodTimeout = unit.toMillis(t)
-    val res = inner.next(math.min(methodTimeout, timeLeft.get), TimeUnit.MILLISECONDS)
-    val time = (System.currentTimeMillis - before).asInstanceOf[Int]
 
-    timeLeft.addAndGet(-time)
-    res
+    try  {
+      return inner.next(math.min(methodTimeout, timeLeft.get), TimeUnit.MILLISECONDS)
+    } finally {
+      val time = (System.currentTimeMillis - before).asInstanceOf[Int]
+      timeLeft.addAndGet(-time)
+    }
   }
 }
 

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/ClientChannelHandler.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/ClientChannelHandler.scala
@@ -147,6 +147,7 @@ class ClientChannelHandler(clientName: Option[String],
 
   def shutdown: Unit = {
     responseHandler.shutdown
+    cleanupExecutor.shutdownNow
     statsJMX.foreach { JMX.unregister(_) }
     serverErrorStrategyJMX.foreach { JMX.unregister(_) }
     clientStatsStrategyJMX.foreach { JMX.unregister(_) }

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/NettyNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/NettyNetworkClient.scala
@@ -115,6 +115,7 @@ abstract class BaseNettyNetworkClient(clientConfig: NetworkClientConfig) extends
     openTimeoutMillis = clientConfig.connectTimeoutMillis,
     writeTimeoutMillis = clientConfig.writeTimeoutMillis,
     bootstrap = bootstrap,
+    closeChannelTimeMillis = clientConfig.closeChannelTimeMillis,
     errorStrategy = Some(channelPoolStrategy))
 
   val clusterIoClient = new NettyClusterIoClient(channelPoolFactory, strategy)


### PR DESCRIPTION
Cleaning up the _entire_ channel pool every K requests should do about as well as a time-based policy, and is closer to the current implementation, so I'm trying it first. Rui & Yasu, what do you think?

Also, I included a change from the seas team to clean up a resource to conserve threads when the service is bounced.
