### PR TITLE
Concurrency issues of atomicCreateIfAbsent function

### DIFF
--- a/cluster/src/main/scala/com/linkedin/norbert/norbertutils/package.scala
+++ b/cluster/src/main/scala/com/linkedin/norbert/norbertutils/package.scala
@@ -43,15 +43,15 @@ package object norbertutils {
 
   // TODO: Put this into a utility somewhere? Scala's concurrent getOrElseUpdate is not atomic, unlike this guy
   def atomicCreateIfAbsent[K, V](map: ConcurrentMap[K, V], key: K)(fn: K => V): V = {
-    val oldValue = map.get(key)
-    if(oldValue == null) {
-      map.synchronized {
+    map.synchronized {
+      val oldValue = map.get(key)
+      if(oldValue == null) {
         val newValue = fn(key)
         map.putIfAbsent(key, newValue)
         map.get(key)
+      } else {
+        oldValue
       }
-    } else {
-      oldValue
     }
   }
 


### PR DESCRIPTION
This change expands the coverage of synchronized protection before caller get the key in concurrent hash map in atomicCreateIfAbsent function. If there are more than two concurrent calls to this function with same key and value, this function calls the parameter function with key which can cause side effects and it is not really atomic creation.
Therefore, we need to expand the synchronized protection.
