### PR TITLE
create one way messages feature

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/Serializer.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/Serializer.scala
@@ -23,6 +23,13 @@ import java.io.{OutputStream, InputStream}
  */
 trait Serializer[RequestMsg, ResponseMsg] extends InputSerializer[RequestMsg, ResponseMsg] with OutputSerializer[RequestMsg, ResponseMsg]
 
+// When there is no response message
+trait OneWaySerializer[RequestMsg] extends InputSerializer[RequestMsg, Unit] with OutputSerializer[RequestMsg, Unit] {
+  override def responseName: String = null
+  override def responseToBytes(response: Unit): Array[Byte] = null
+  override def responseFromBytes(bytes: Array[Byte]): Unit = null
+}
+
 // Split up for correct variance
 trait OutputSerializer[-RequestMsg, -ResponseMsg] {
   def responseName: String

--- a/network/src/main/scala/com/linkedin/norbert/network/common/BaseNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/common/BaseNetworkClient.scala
@@ -98,7 +98,7 @@ trait BaseNetworkClient extends Logging {
     val candidate = currentNodes.filter(_ == node)
     if (candidate.size == 0) throw new InvalidNodeException("Unable to send message, %s is not available".format(node))
 
-    doSendRequest(Request(request, node, is, os, callback))
+    doSendRequest(Request(request, node, is, os, Some(callback)))
   }
 
 
@@ -135,7 +135,7 @@ trait BaseNetworkClient extends Logging {
     val nodes = currentNodes
     val queue = new ResponseQueue[ResponseMsg]
 
-    currentNodes.foreach { node: Node => (Request(request, node, is, os, queue +=)) }
+    currentNodes.foreach { node: Node => Request(request, node, is, os, Some((a: Either[Throwable, ResponseMsg]) => {queue += a :Unit})) }
 
     new NorbertResponseIterator(nodes.size, queue)
   }

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/ClientChannelHandler.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/ClientChannelHandler.scala
@@ -100,8 +100,10 @@ class ClientChannelHandler(clientName: Option[String],
     val request = e.getMessage.asInstanceOf[Request[_, _]]
     log.debug("Writing request: %s".format(request))
 
-    requestMap.put(request.id, request)
-    stats.beginRequest(request.node, request.id)
+    if(!request.callback.isEmpty) {
+      requestMap.put(request.id, request)
+      stats.beginRequest(request.node, request.id)
+    }
 
     val message = NorbertProtos.NorbertMessage.newBuilder
     message.setRequestIdMsb(request.id.getMostSignificantBits)

--- a/network/src/main/scala/com/linkedin/norbert/network/netty/ServerChannelHandler.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/netty/ServerChannelHandler.scala
@@ -135,9 +135,9 @@ class ServerChannelHandler(clientName: Option[String],
     val request = is.requestFromBytes(requestBytes)
 
     try {
-      messageExecutor.executeMessage(request, (either: Either[Exception, Any]) => {
+      messageExecutor.executeMessage(request, Option((either: Either[Exception, Any]) => {
         responseHandler(context, e.getChannel, either)(is, os)
-      }, Some(context))(is)
+      }), Some(context))(is)
     }
     catch {
       case ex: HeavyLoadException =>

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -79,8 +79,8 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
     val node = loadBalancer.getOrElse(throw new ClusterDisconnectedException).fold(ex => throw ex,
     lb => lb.nextNode(id, capability, persistentCapability).getOrElse(throw new NoNodesAvailableException("Unable to satisfy request, no node available for id %s".format(id))))
 
-  doSendRequest(PartitionedRequest(request, node, Set(id), (node: Node, ids: Set[PartitionedId]) => request, is, os, None))
-}
+    doSendRequest(PartitionedRequest(request, node, Set(id), (node: Node, ids: Set[PartitionedId]) => request, is, os, None))
+  }
 
   /**
    * Sends a <code>Message</code> to the specified <code>PartitionedId</code>. The <code>PartitionedNetworkClient</code>

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -107,6 +107,20 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
     }
   }
 
+  def sendMessage[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg, capability: Option[Long])
+                                          (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]) {
+    doIfConnected {
+      sendMessage(ids, requestBuilder, capability, None)(is, os)
+    }
+  }
+
+  def sendMessage[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg)
+                                          (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]) {
+    doIfConnected {
+      sendMessage(ids, requestBuilder, None, None)(is, os)
+    }
+  }
+
   def sendMessage[RequestMsg, ResponseMsg](ids: Set[PartitionedId], requestBuilder: (Node, Set[PartitionedId]) => RequestMsg, capability: Option[Long], persistentCapability: Option[Long])
                                           (implicit is: InputSerializer[RequestMsg, ResponseMsg], os: OutputSerializer[RequestMsg, ResponseMsg]) {
     doIfConnected {

--- a/network/src/main/scala/com/linkedin/norbert/network/server/MessageExecutorComponent.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/server/MessageExecutorComponent.scala
@@ -125,7 +125,7 @@ class ThreadPoolMessageExecutor(clientName: Option[String],
       if(now - queuedAt > requestTimeout) {
         totalNumRejected.incrementAndGet
         log.warn("Request timed out, ignoring! Currently = " + now + ". Queued at = " + queuedAt + ". Timeout = " + requestTimeout)
-        if(!callback.isEmpty) callback.get(Left(new HeavyLoadException))
+        callback.foreach(_(Left(new HeavyLoadException)))
       } else {
         log.debug("Executing message: %s".format(request))
 

--- a/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
@@ -102,7 +102,7 @@ class NetworkClientSpec extends BaseNetworkClientSpecification {
       }
 
       "request.retryAttempt >= maxRetry" in {
-        val req: Request[Ping, Ping] = spy(Request[Ping, Ping](null, null, null, null, callback, MAX_RETRY))
+        val req: Request[Ping, Ping] = spy(Request[Ping, Ping](null, null, null, null, Some(callback), MAX_RETRY))
         val ra: Exception with RequestAccess[Request[Ping, Ping]] = new Exception with RequestAccess[Request[Ping, Ping]] {
           def request = req
         }
@@ -135,7 +135,7 @@ class NetworkClientSpec extends BaseNetworkClientSpecification {
 
         networkClient.start
 
-        var req: Request[Ping, Ping] = spy(Request[Ping, Ping](null, nodes(1), null, null, callback))
+        var req: Request[Ping, Ping] = spy(Request[Ping, Ping](null, nodes(1), null, null, Some(callback)))
         val ra: Exception with RequestAccess[Request[Ping, Ping]] = new Exception with RequestAccess[Request[Ping, Ping]] {
           def request = req
         }

--- a/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/client/NetworkClientSpec.scala
@@ -77,7 +77,7 @@ class NetworkClientSpec extends BaseNetworkClientSpecification {
 //      clusterIoClient.sendMessage(node, message, null) was called
     }
 
-    "send the provided message to the node specified by the load balancer for sendMessage with the requested capability " in {
+    "send the provided message to the node specified by the load balancer for sendRequest with the requested capability " in {
       clusterClient.nodes returns nodeSet
       clusterClient.isConnected returns true
       networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
@@ -86,6 +86,20 @@ class NetworkClientSpec extends BaseNetworkClientSpecification {
 
       networkClient.start
       networkClient.sendRequest(request, Some(1L), Some(2L)) must notBeNull
+
+      there was one(networkClient.lb).nextNode(Some(0x1), Some(2L))
+      there was no(networkClient.lb).nextNode(None, None)
+    }
+
+    "send the provided message to the node specified by the load balancer for sendMessage with the requested capability " in {
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
+      networkClient.lb.nextNode(Some(0x1), Some(2L)) returns Some(nodes(1))
+
+      networkClient.start
+      networkClient.sendMessage(request, Some(1L), Some(2L)) must notBeNull
 
       there was one(networkClient.lb).nextNode(Some(0x1), Some(2L))
       there was no(networkClient.lb).nextNode(None, None)

--- a/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/common/LocalMessageExecutionSpec.scala
@@ -35,13 +35,13 @@ class LocalMessageExecutionSpec extends Specification with Mockito with SampleMe
     val filters = new MutableList[Filter]
     def shutdown = {}
 
-    def executeMessage[RequestMsg, ResponseMsg](request: RequestMsg, responseHandler: (Either[Exception, ResponseMsg]) => Unit, context: Option[RequestContext])(implicit is: InputSerializer[RequestMsg, ResponseMsg]) = {
+    def executeMessage[RequestMsg, ResponseMsg](request: RequestMsg, responseHandler: Option[(Either[Exception, ResponseMsg]) => Unit], context: Option[RequestContext])(implicit is: InputSerializer[RequestMsg, ResponseMsg]) = {
       called = true
       this.request = request
 
       val response = null.asInstanceOf[ResponseMsg]
 
-      responseHandler(Right(response))
+      responseHandler.get(Right(response))
     }
   }
 

--- a/network/src/test/scala/com/linkedin/norbert/network/netty/ChannelPoolSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/netty/ChannelPoolSpec.scala
@@ -197,7 +197,7 @@ class ChannelPoolSpec extends Specification with Mockito {
     "properly handle a failed write" in {
       val channel = mock[Channel]
       var either: Either[Throwable, Any] = null
-      val request = spy(Request(null, null, null, null, (e: Either[Throwable, Any]) => either = e))
+      val request = spy(Request(null, null, null, null, Some((e: Either[Throwable, Any]) => either = e)))
       request.timestamp returns System.currentTimeMillis + 10000
       channel.isConnected returns true
       val openFuture = new TestChannelFuture(channel, true)
@@ -217,7 +217,7 @@ class ChannelPoolSpec extends Specification with Mockito {
     "invoke callback when remote exception encountered" in {
       val channel = mock[Channel]
       var either: Either[Throwable, Any] = null
-      val request = spy(Request(null, null, null, null, (e: Either[Throwable, Any]) => either = e))
+      val request = spy(Request(null, null, null, null, Some((e: Either[Throwable, Any]) => either = e)))
       request.timestamp returns System.currentTimeMillis
       channel.isConnected returns true
       val openFuture = new TestChannelFuture(channel, true)
@@ -236,10 +236,10 @@ class ChannelPoolSpec extends Specification with Mockito {
 
     "not write queued requests if the request timed out" in {
       val channel = mock[Channel]
-      val goodRequest = spy(new Request(null, null, null, null, (e: Either[Throwable, Any]) => null))
+      val goodRequest = spy(new Request(null, null, null, null, Some((e: Either[Throwable, Any]) => null: Unit)))
 
       var either: Either[Throwable, Any] = null
-      val badRequest = spy(new Request(null, null, null, null, (e: Either[Throwable, Any]) => either = e))
+      val badRequest = spy(new Request(null, null, null, null, Some((e: Either[Throwable, Any]) => either = e)))
 
       goodRequest.timestamp returns System.currentTimeMillis + 10000
       badRequest.timestamp returns System.currentTimeMillis - 10000

--- a/network/src/test/scala/com/linkedin/norbert/network/netty/ClientChannelHandlerSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/netty/ClientChannelHandlerSpec.scala
@@ -43,7 +43,7 @@ class ClientChannelHandlerSpec extends Specification with Mockito with SampleMes
       channel.getRemoteAddress returns mock[SocketAddress]
       val ctx = mock[ChannelHandlerContext]
       ctx.getChannel returns channel
-      val request = Request[Ping, Ping](Ping(System.currentTimeMillis), Node(1, "localhost:1234", true), Ping.PingSerializer, Ping.PingSerializer, { e => e })
+      val request = Request[Ping, Ping](Ping(System.currentTimeMillis), Node(1, "localhost:1234", true), Ping.PingSerializer, Ping.PingSerializer, Some({ e => e }))
       sendMockRequest(ctx, request)
 
       val readEvent = mock[MessageEvent]
@@ -62,7 +62,7 @@ class ClientChannelHandlerSpec extends Specification with Mockito with SampleMes
       channel.getRemoteAddress returns mock[SocketAddress]
       val ctx = mock[ChannelHandlerContext]
       ctx.getChannel returns channel
-      val request = Request[Ping, Ping](Ping(System.currentTimeMillis), Node(1, "localhost:1234", true), Ping.PingSerializer, Ping.PingSerializer, { e => e })
+      val request = Request[Ping, Ping](Ping(System.currentTimeMillis), Node(1, "localhost:1234", true), Ping.PingSerializer, Ping.PingSerializer, Some({ e => e }))
       sendMockRequest(ctx, request)
 
       val norbertMessage = NorbertProtos.NorbertMessage.newBuilder().setStatus(Status.ERROR)

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
@@ -451,7 +451,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
       }
 
       "request.retryAttempt >= maxRetry" in {
-        val req: Request[Ping, Ping] = spy(PartitionedRequest[Int, Ping, Ping](null, null, null, null, null, null, callback, MAX_RETRY))
+        val req: Request[Ping, Ping] = spy(PartitionedRequest[Int, Ping, Ping](null, null, null, null, null, null, Some(callback), MAX_RETRY))
         val ra: Exception with RequestAccess[Request[Ping, Ping]] = new Exception with RequestAccess[Request[Ping, Ping]] {
           def request = req
         }
@@ -484,7 +484,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
 
         networkClient.start
 
-        var req: Request[Ping, Ping] = spy(PartitionedRequest[Int, Ping, Ping](null, nodes(1), null, null, null, null, callback, 0))
+        var req: Request[Ping, Ping] = spy(PartitionedRequest[Int, Ping, Ping](null, nodes(1), null, null, null, null, Some(callback), 0))
         val ra: Exception with RequestAccess[Request[Ping, Ping]] = new Exception with RequestAccess[Request[Ping, Ping]] {
           def request = req
         }

--- a/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClientSpec.scala
@@ -84,16 +84,31 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
         networkClient.lb.nextNode(1, None, None) returns Some(nodes(1))
-//      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(1, request) must notBeNull
 
         there was one(networkClient.lb).nextNode(1, None, None)
-//      clusterIoClient.sendRequest(node, message, null) was called
+        //      clusterIoClient.sendRequest(node, message, null) was called
       }
 
-      "send the provided message to the node specified by the load balancer filtering based on capability" in {
+      "send the provided message to the node specified by the load balancer for sendMessage" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+        networkClient.lb.nextNode(1, None, None) returns Some(nodes(1))
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+
+        networkClient.start
+        networkClient.sendMessage(1, request) must notBeNull
+
+        there was one(networkClient.lb).nextNode(1, None, None)
+        //      clusterIoClient.sendRequest(node, message, null) was called
+      }
+
+      "send the provided message to the node specified by the load balancer filtering based on capability for sendRequest" in {
         clusterClient.nodes returns nodeSet
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
@@ -106,18 +121,45 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         there was one(networkClient.lb).nextNode(1, Some(0x1L), Some(2L))
         there was no(networkClient.lb).nextNode(1, None, None)
       }
-      
+
+      "send the provided message to the node specified by the load balancer filtering based on capability fir sendMessage" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+        networkClient.lb.nextNode(1, Some(0x1), Some(0x2)) returns Some(nodes(1))
+
+        networkClient.start
+        networkClient.sendMessage(1, request, Some(0x1L), Some(2L)) must notBeNull
+
+        there was one(networkClient.lb).nextNode(1, Some(0x1L), Some(2L))
+        there was no(networkClient.lb).nextNode(1, None, None)
+      }
+
       "throw InvalidClusterException if there is no load balancer instance when sendRequest is called" in {
         clusterClient.nodes returns nodeSet
         clusterClient.isConnected returns true
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) throws new InvalidClusterException("")
-//      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(1, request) must throwA[InvalidClusterException]
 
-//      clusterIoClient.sendRequest(node, message, null) wasnt called
+        //      clusterIoClient.sendRequest(node, message, null) wasnt called
+      }
+
+      "throw InvalidClusterException if there is no load balancer instance when sendMessage is called" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) throws new InvalidClusterException("")
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+
+        networkClient.start
+        networkClient.sendMessage(1, request) must throwA[InvalidClusterException]
+
+        //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
 
       "throw NoSuchNodeException if load balancer returns None when sendRequest is called" in {
@@ -126,13 +168,28 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
         networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
         networkClient.lb.nextNode(1, None, None) returns None
-//      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(1, request) must throwA[NoNodesAvailableException]
 
         there was one(networkClient.lb).nextNode(1, None, None)
-//      clusterIoClient.sendRequest(node, message, null) wasnt called
+        //      clusterIoClient.sendRequest(node, message, null) wasnt called
+      }
+
+      "throw NoSuchNodeException if load balancer returns None when sendMessage is called" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.lb
+        networkClient.lb.nextNode(1, None, None) returns None
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+
+        networkClient.start
+        networkClient.sendMessage(1, request) must throwA[NoNodesAvailableException]
+
+        there was one(networkClient.lb).nextNode(1, None, None)
+        //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
     }
 
@@ -146,7 +203,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         networkClient.lb.nextNode(2, None, None) returns Some(nodes(2))
         networkClient.lb.nextNode(3, None, None) returns Some(nodes(1))
 
-//      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), request) must notBeNull
@@ -156,7 +213,29 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
           one(networkClient.lb).nextNode(2, None, None)
           one(networkClient.lb).nextNode(3, None, None)
         }
-//      clusterIoClient.sendRequest(node, message, null) was called
+        //      clusterIoClient.sendRequest(node, message, null) was called
+      }
+
+      "send the provided one way message to the node specified by the load balancer" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+        networkClient.lb.nextNode(1, None, None) returns Some(nodes(1))
+        networkClient.lb.nextNode(2, None, None) returns Some(nodes(2))
+        networkClient.lb.nextNode(3, None, None) returns Some(nodes(1))
+
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+
+        networkClient.start
+        networkClient.sendMessage(Set(1, 2, 3), request) must notBeNull
+
+        got {
+          one(networkClient.lb).nextNode(1, None, None)
+          one(networkClient.lb).nextNode(2, None, None)
+          one(networkClient.lb).nextNode(3, None, None)
+        }
+        //      clusterIoClient.sendRequest(node, message, null) was called
       }
 
       "send the provided message to the node specified by the load balancer with capability filter" in {
@@ -174,13 +253,39 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
         networkClient.sendRequest(Set(1, 2, 3), request, Some(0xffL), Some(2L)) must notBeNull
 
         got {
-              no(networkClient.lb).nextNode(1, None, None)
-              no(networkClient.lb).nextNode(2, None, None)
-              no(networkClient.lb).nextNode(3, None, None)
-              one(networkClient.lb).nextNode(1, Some(0xffL), Some(2L))
-              one(networkClient.lb).nextNode(2, Some(0xffL), Some(2L))
-              one(networkClient.lb).nextNode(3, Some(0xffL), Some(2L))
-            }
+          no(networkClient.lb).nextNode(1, None, None)
+          no(networkClient.lb).nextNode(2, None, None)
+          no(networkClient.lb).nextNode(3, None, None)
+          one(networkClient.lb).nextNode(1, Some(0xffL), Some(2L))
+          one(networkClient.lb).nextNode(2, Some(0xffL), Some(2L))
+          one(networkClient.lb).nextNode(3, Some(0xffL), Some(2L))
+        }
+        //      clusterIoClient.sendRequest(node, message, null) was called
+      }
+
+
+      "send the provided one way message to the node specified by the load balancer with capability filter" in {
+        clusterClient.nodes returns nodeSet
+        clusterClient.isConnected returns true
+        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+        networkClient.lb.nextNode(1, Some(0xffL), Some(2L)) returns Some(nodes(1))
+        networkClient.lb.nextNode(2, Some(0xffL), Some(2L)) returns Some(nodes(2))
+        networkClient.lb.nextNode(3, Some(0xffL), Some(2L)) returns Some(nodes(1))
+
+        //      doNothing.when(clusterIoClient).sendRequest(node, message, null)
+
+        networkClient.start
+        networkClient.sendMessage(Set(1, 2, 3), request, Some(0xffL), Some(2L)) must notBeNull
+
+        got {
+          no(networkClient.lb).nextNode(1, None, None)
+          no(networkClient.lb).nextNode(2, None, None)
+          no(networkClient.lb).nextNode(3, None, None)
+          one(networkClient.lb).nextNode(1, Some(0xffL), Some(2L))
+          one(networkClient.lb).nextNode(2, Some(0xffL), Some(2L))
+          one(networkClient.lb).nextNode(3, Some(0xffL), Some(2L))
+        }
         //      clusterIoClient.sendRequest(node, message, null) was called
       }
 
@@ -244,65 +349,108 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
 
 
   "when sendRequest(ids, message, messageCustomizer) is called" in {
-      "send the provided message to the node specified by the load balancer" in {
-        clusterClient.nodes returns nodeSet
-        clusterClient.isConnected returns true
-        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
-        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
-        List(1, 2, 3).foreach(networkClient.lb.nextNode(_, None, None) returns Some(Node(1, "localhost:31313", true)))
+    "send the provided message to the node specified by the load balancer" in {
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+      List(1, 2, 3).foreach(networkClient.lb.nextNode(_, None, None) returns Some(Node(1, "localhost:31313", true)))
 
-        networkClient.start
-        networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _)
+      networkClient.start
+      networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _)
 
-        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_, None, None))
+      List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_, None, None))
 
-        List(1, 2, 3).foreach(networkClient.lb.nextNode(_, Some(0x3L), Some(0L)) returns Some(Node(1, "localhost:31313", true)))
-        networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _, Some(0x3L), Some(0L))
-        List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_,Some(0x3L), Some(0L)))
+      List(1, 2, 3).foreach(networkClient.lb.nextNode(_, Some(0x3L), Some(0L)) returns Some(Node(1, "localhost:31313", true)))
+      networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _, Some(0x3L), Some(0L))
+      List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_,Some(0x3L), Some(0L)))
+    }
+
+    "send the provided one way message to the node specified by the load balancer" in {
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+      List(1, 2, 3).foreach(networkClient.lb.nextNode(_, None, None) returns Some(Node(1, "localhost:31313", true)))
+
+      networkClient.start
+      networkClient.sendMessage(Set(1, 2, 3), messageCustomizer _)
+
+      List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_, None, None))
+
+      List(1, 2, 3).foreach(networkClient.lb.nextNode(_, Some(0x3L), Some(0L)) returns Some(Node(1, "localhost:31313", true)))
+      networkClient.sendMessage(Set(1, 2, 3), messageCustomizer _, Some(0x3L), Some(0L))
+      List(1, 2, 3).foreach(there was one(networkClient.lb).nextNode(_,Some(0x3L), Some(0L)))
+    }
+
+    "call the message customizer" in {
+      var callCount = 0
+      var nodeMap = Map[Node, Set[Int]]()
+
+      def mc(node: Node, ids: Set[Int]): Ping = {
+        callCount += 1
+        nodeMap = nodeMap + (node -> ids)
+        new Ping
       }
 
-      "call the message customizer" in {
-        var callCount = 0
-        var nodeMap = Map[Node, Set[Int]]()
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+      List(1, 2).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(0)))
+      List(3, 4).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(1)))
 
-        def mc(node: Node, ids: Set[Int]): Ping = {
-          callCount += 1
-          nodeMap = nodeMap + (node -> ids)
-          new Ping
-        }
+      networkClient.start
+      networkClient.sendRequest(Set(1, 2, 3, 4), mc _)
 
-        clusterClient.nodes returns nodeSet
-        clusterClient.isConnected returns true
-        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
-        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
-        List(1, 2).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(0)))
-        List(3, 4).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(1)))
+      callCount must be_==(2)
+      nodeMap.size must be_==(2)
+      nodeMap(nodes(0)) must haveTheSameElementsAs(Array(1, 2))
+      nodeMap(nodes(1)) must haveTheSameElementsAs(Array(3, 4))
+    }
 
-        networkClient.start
-        networkClient.sendRequest(Set(1, 2, 3, 4), mc _)
+    "call the message customizer (one way message)" in {
+      var callCount = 0
+      var nodeMap = Map[Node, Set[Int]]()
 
-        callCount must be_==(2)
-        nodeMap.size must be_==(2)
-        nodeMap(nodes(0)) must haveTheSameElementsAs(Array(1, 2))
-        nodeMap(nodes(1)) must haveTheSameElementsAs(Array(3, 4))
+      def mc(node: Node, ids: Set[Int]): Ping = {
+        callCount += 1
+        nodeMap = nodeMap + (node -> ids)
+        new Ping
       }
 
-      "treats an exception from the message customizer as a failed response" in {
-        def mc(node: Node, ids: Set[Int]): Ping = {
-          throw new Exception
-        }
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+      List(1, 2).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(0)))
+      List(3, 4).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(1)))
 
-        clusterClient.nodes returns nodeSet
-        clusterClient.isConnected returns true
-        networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
-        networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
-        List(1, 2).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(0)))
+      networkClient.start
+      networkClient.sendMessage(Set(1, 2, 3, 4), mc _)
 
-        networkClient.start
-        val ri = networkClient.sendRequest(Set(1, 2), mc _)
-        ri.hasNext must beTrue
-        ri.next must throwA[ExecutionException]
+      callCount must be_==(2)
+      nodeMap.size must be_==(2)
+      nodeMap(nodes(0)) must haveTheSameElementsAs(Array(1, 2))
+      nodeMap(nodes(1)) must haveTheSameElementsAs(Array(3, 4))
+    }
+
+    "treats an exception from the message customizer as a failed response" in {
+      def mc(node: Node, ids: Set[Int]): Ping = {
+        throw new Exception
       }
+
+      clusterClient.nodes returns nodeSet
+      clusterClient.isConnected returns true
+      networkClient.clusterIoClient.nodesChanged(nodeSet) returns endpoints
+      networkClient.loadBalancerFactory.newLoadBalancer(endpoints) returns networkClient.loadbalancer
+      List(1, 2).foreach(networkClient.lb.nextNode(_, None, None) returns Some(nodes(0)))
+
+      networkClient.start
+      val ri = networkClient.sendRequest(Set(1, 2), mc _)
+      ri.hasNext must beTrue
+      ri.next must throwA[ExecutionException]
+    }
 
       "throw InvalidClusterException if there is no load balancer instance when sendRequest is called" in {
         clusterClient.nodes returns nodeSet
@@ -313,6 +461,7 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _)  must throwA[InvalidClusterException]
+        networkClient.sendMessage(Set(1, 2, 3), messageCustomizer _)  must throwA[InvalidClusterException]
 
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
@@ -327,8 +476,9 @@ class PartitionedNetworkClientSpec extends BaseNetworkClientSpecification {
 
         networkClient.start
         networkClient.sendRequest(Set(1, 2, 3), messageCustomizer _) must throwA[NoNodesAvailableException]
+        networkClient.sendMessage(Set(1, 2, 3), messageCustomizer _) must throwA[NoNodesAvailableException]
 
-        there was one(networkClient.lb).nextNode(1, None, None)
+        there were two(networkClient.lb).nextNode(1, None, None)
 //      clusterIoClient.sendRequest(node, message, null) wasnt called
       }
     }

--- a/network/src/test/scala/com/linkedin/norbert/network/server/MessageExecutorSpec.scala
+++ b/network/src/test/scala/com/linkedin/norbert/network/server/MessageExecutorSpec.scala
@@ -64,7 +64,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
     "find the handler associated with the specified message" in {
       messageHandlerRegistry.handlerFor(request) returns returnHandler _
 
-      messageExecutor.executeMessage(request, (either: Either[Exception, Ping]) => null, None)
+      messageExecutor.executeMessage(request, Some((either: Either[Exception, Ping]) => null:Unit), None)
 
       waitFor(50.ms)
 
@@ -79,7 +79,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
       }
       messageHandlerRegistry.handlerFor(request) returns h _
 
-      messageExecutor.executeMessage(request, (either: Either[Exception, Ping]) => null, None)
+      messageExecutor.executeMessage(request, Some((either: Either[Exception, Ping]) => null:Unit), None)
 
       wasCalled must eventually(beTrue)
     }
@@ -88,7 +88,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
 //      messageHandlerRegistry.validResponseFor(request, request) returns true
       messageHandlerRegistry.handlerFor(request) returns returnHandler _
 
-      messageExecutor.executeMessage(request, handler _)
+      messageExecutor.executeMessage(request, Some(handler _))
 
       handlerCalled must eventually(beTrue)
       either.isRight must beTrue
@@ -99,7 +99,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
 //      messageHandlerRegistry.validResponseFor(request, null) returns true
       messageHandlerRegistry.handlerFor(request) returns nullHandler _
 
-      messageExecutor.executeMessage(request, handler _)
+      messageExecutor.executeMessage(request, Some(handler _))
 
       handlerCalled must eventually(beFalse)
     }
@@ -107,7 +107,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
     "execute the responseHandler with Left(ex) if the handler throws an exception" in {
       messageHandlerRegistry.handlerFor(request) returns throwsHandler _
 
-      messageExecutor.executeMessage(request, handler _)
+      messageExecutor.executeMessage(request, Some(handler _))
 
       handlerCalled must eventually(beTrue)
       either.isLeft must beTrue
@@ -116,7 +116,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
     "not execute the responseHandler if the message is not registered" in {
       messageHandlerRegistry.handlerFor(request) throws new InvalidMessageException("")
 
-      messageExecutor.executeMessage(request, handler _)
+      messageExecutor.executeMessage(request, Some(handler _))
 
       waitFor(5.ms)
 
@@ -127,7 +127,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
 
     "filters are executed when message is valid" in {
       messageHandlerRegistry.handlerFor(request) returns returnHandler _
-      messageExecutor.executeMessage(request, (either: Either[Exception, Ping]) => null, Some(requestContext))
+      messageExecutor.executeMessage(request, Some((either: Either[Exception, Ping]) => null:Unit), Some(requestContext))
 
       waitFor(5.ms)
       there was one(filter1).onRequest(request, requestContext) then one(filter2).onRequest(request, requestContext) orderedBy(filter1, filter2)
@@ -136,7 +136,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
 
     "filters are not executed when handler return null" in {
       messageHandlerRegistry.handlerFor(request) returns nullHandler _
-      messageExecutor.executeMessage(request, handler _, Some(requestContext))
+      messageExecutor.executeMessage(request, Some(handler _), Some(requestContext))
 
       waitFor(5.ms)
       there was one(filter1).onRequest(request, requestContext) then one(filter2).onRequest(request, requestContext) orderedBy(filter1, filter2)
@@ -145,7 +145,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
 
     "filters are executed when handler throws an exception" in {
       messageHandlerRegistry.handlerFor(request) returns throwsHandler _
-      messageExecutor.executeMessage(request, handler _, Some(requestContext))
+      messageExecutor.executeMessage(request, Some(handler _), Some(requestContext))
       
       waitFor(5.ms)
       there was one(filter1).onRequest(request, requestContext) then one(filter2).onRequest(request, requestContext) orderedBy(filter1, filter2)
@@ -157,7 +157,7 @@ class MessageExecutorSpec extends Specification with Mockito with WaitFor with S
     "filters are executed when message is not registered" in {
       val ie = new InvalidMessageException("")
       messageHandlerRegistry.handlerFor(request) throws ie
-      messageExecutor.executeMessage(request, handler _, Some(requestContext))
+      messageExecutor.executeMessage(request, Some(handler _), Some(requestContext))
 
       waitFor(5.ms)
       there was one(filter1).onRequest(request, requestContext) then one(filter2).onRequest(request, requestContext) orderedBy(filter1, filter2)


### PR DESCRIPTION
I implemented one way messages by making callbacks optional on the client side and using serializers that return Unit as one way serializers, indicating that there can be no response.

This is a better way of doing what I did here: https://github.com/linkedin-sna/norbert/pull/22
